### PR TITLE
Update project url, license url and authors

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.nuspec
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.nuspec
@@ -3,10 +3,10 @@
   <metadata>
     <id>NuGet.CommandLine</id>
     <version>3.6.0</version>
-    <authors>Microsoft</authors>
+    <authors>Microsoft, Octopus Deploy</authors>
     <owners>Microsoft</owners>
-    <licenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt</licenseUrl>
-    <projectUrl>https://github.com/NuGet/NuGet.Client</projectUrl>
+    <licenseUrl>https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt</licenseUrl>
+    <projectUrl>https://github.com/OctopusDeploy/NuGet.Client</projectUrl>
     <copyright>&#169; .NET Foundation. All rights reserved.</copyright>
     <description>NuGet Command Line Tool</description>
     <developmentDependency>true</developmentDependency>

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/PackageManagement.PowerShellCmdlets.nuspec
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/PackageManagement.PowerShellCmdlets.nuspec
@@ -4,11 +4,11 @@
     <id>NuGet.PackageManagement.PowerShellCmdlets</id>
     <version>1.0.0-overrideme</version>
     <title>NuGet's PowerShell Cmdlets for the Visual Studio client</title>
-    <authors>NuGet</authors>
+    <authors>NuGet, Octopus Deploy</authors>
     <copyright>Copyright .NET Foundation. All rights reserved.</copyright>
     <owners>NuGet</owners>
-    <projectUrl>https://github.com/NuGet/NuGet.Client/</projectUrl>
-    <licenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt</licenseUrl>
+    <projectUrl>https://github.com/OctopusDeploy/NuGet.Client/</projectUrl>
+    <licenseUrl>https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>NuGet's PowerShell Cmdlets for the Visual Studio client</description>
     <dependencies>

--- a/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.nuspec
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.nuspec
@@ -4,11 +4,11 @@
     <id>NuGet.PackageManagement.UI</id>
     <version>1.0.0-overrideme</version>
     <title>NuGet's Package Management UI for Visual Studio</title>
-    <authors>NuGet</authors>
+    <authors>NuGet, Octopus Deploy</authors>
     <copyright>Copyright .NET Foundation. All rights reserved.</copyright>
     <owners>NuGet</owners>
-    <projectUrl>https://github.com/NuGet/NuGet.Client</projectUrl>
-    <licenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt</licenseUrl>
+    <projectUrl>https://github.com/OctopusDeploy/NuGet.Client</projectUrl>
+    <licenseUrl>https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>NuGet's Package Management UI for Visual Studio</description>
     <dependencies>

--- a/src/NuGet.Clients/VisualStudio/NuGet.VisualStudio.nuspec
+++ b/src/NuGet.Clients/VisualStudio/NuGet.VisualStudio.nuspec
@@ -3,10 +3,10 @@
   <metadata>
     <id>NuGet.VisualStudio</id>
     <version>$version$</version>
-    <authors>Microsoft</authors>
+    <authors>Microsoft, Octopus Deploy</authors>
     <owners>Microsoft</owners>
-    <licenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt</licenseUrl>
-    <projectUrl>https://github.com/NuGet/NuGet.Client</projectUrl>
+    <licenseUrl>https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt</licenseUrl>
+    <projectUrl>https://github.com/OctopusDeploy/NuGet.Client</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>APIs for invoking NuGet services in Visual Studio.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/NuGet.Core/NuGet.Client/project.json
+++ b/src/NuGet.Core/NuGet.Client/project.json
@@ -1,10 +1,14 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -1,9 +1,13 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "description": "NuGet 3 restore for dotnet CLI, DNX, and UWP",
   "buildOptions": {

--- a/src/NuGet.Core/NuGet.Commands/project.json
+++ b/src/NuGet.Core/NuGet.Commands/project.json
@@ -1,9 +1,13 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "description": "Complete commands common to command-line and GUI NuGet clients",
   "buildOptions": {

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -1,10 +1,14 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -1,7 +1,8 @@
 ﻿{
   "version": "3.6.0-*",
   "authors": [
-    "NuGet"
+    "NuGet",
+    "Octopus Deploy"
   ],
   "description": "NuGet's client configuration settings implementation.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
@@ -11,8 +12,8 @@
       "configuration",
       "nuget.config"
     ],
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -1,10 +1,14 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
@@ -1,10 +1,14 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver/project.json
@@ -1,10 +1,14 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -2,12 +2,13 @@
   "version": "3.6.0-*",
   "description": "The understanding of target frameworks for NuGet.Packaging",
   "authors": [
-    "NuGet"
+    "NuGet",
+    "Octopus Deploy"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Indexing/project.json
+++ b/src/NuGet.Core/NuGet.Indexing/project.json
@@ -1,9 +1,13 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "description": "NuGet.Indexing Class Library",
   "buildOptions": {

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -1,10 +1,14 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "dependencies": {
     "NuGet.Versioning": {

--- a/src/NuGet.Core/NuGet.PackageManagement/project.json
+++ b/src/NuGet.Core/NuGet.PackageManagement/project.json
@@ -1,9 +1,13 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "description": "NuGet Package Management",
   "buildOptions": {

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -1,10 +1,14 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "dependencies": {
     "NuGet.Frameworks": {

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -2,12 +2,13 @@
   "version": "3.6.0-*",
   "description": "The core data structures for NuGet.Packaging",
   "authors": [
-    "NuGet"
+    "NuGet",
+    "Octopus Deploy"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -2,7 +2,8 @@
   "version": "3.6.0-*",
   "description": "NuGet's implementation for reading nupkg package and nuspec package specification files.",
   "authors": [
-    "NuGet"
+    "NuGet",
+    "Octopus Deploy"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
@@ -10,8 +11,8 @@
       "semver",
       "semantic versioning"
     ],
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.ProjectManagement/project.json
+++ b/src/NuGet.Core/NuGet.ProjectManagement/project.json
@@ -1,9 +1,13 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "description": "NuGet Project Management",
   "buildOptions": {

--- a/src/NuGet.Core/NuGet.ProjectModel/project.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/project.json
@@ -1,10 +1,14 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "dependencies": {
     "NuGet.DependencyResolver.Core": {

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
@@ -1,7 +1,8 @@
 ﻿{
   "version": "3.6.0-*",
   "authors": [
-    "NuGet"
+    "NuGet",
+    "Octopus Deploy"
   ],
   "description": "NuGet's protocol-level base types used for connecting to API v2 and API v3 repositories.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
@@ -9,8 +10,8 @@
     "tags": [
       "nuget protocol"
     ],
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -1,7 +1,8 @@
 ﻿{
   "version": "3.6.0-*",
   "authors": [
-    "NuGet"
+    "NuGet",
+    "Octopus Deploy"
   ],
   "description": "NuGet Protocol v2",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
@@ -9,8 +10,8 @@
     "tags": [
       "nuget protocol"
     ],
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -1,7 +1,8 @@
 ﻿{
   "version": "3.6.0-*",
   "authors": [
-    "NuGet"
+    "NuGet",
+    "Octopus Deploy"
   ],
   "description": "NuGet Protocol for 3.1.0 servers",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
@@ -9,8 +10,8 @@
     "tags": [
       "nuget protocol"
     ],
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -1,9 +1,13 @@
 ﻿{
   "version": "1.0.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
@@ -1,7 +1,8 @@
 ﻿{
   "version": "3.6.0-*",
   "authors": [
-    "NuGet"
+    "NuGet",
+    "Octopus Deploy"
   ],
   "description": "NuGet Protocol for Visual Studio",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
@@ -9,8 +10,8 @@
     "tags": [
       "nuget protocol"
     ],
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -1,10 +1,14 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "dependencies": {
     "NuGet.Packaging": {

--- a/src/NuGet.Core/NuGet.Resolver/project.json
+++ b/src/NuGet.Core/NuGet.Resolver/project.json
@@ -2,12 +2,13 @@
   "version": "3.6.0-*",
   "description": "NuGet's dependency resolver within the NuGet.Packaging package",
   "authors": [
-    "NuGet"
+    "NuGet",
+    "Octopus Deploy"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -1,10 +1,14 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -1,9 +1,13 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -1,9 +1,13 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/NuGet.Versioning/project.json
+++ b/src/NuGet.Core/NuGet.Versioning/project.json
@@ -1,7 +1,8 @@
 ﻿{
   "version": "3.6.0-*",
   "authors": [
-    "NuGet"
+    "NuGet",
+    "Octopus Deploy"
   ],
   "description": "NuGet's implementation of Semantic Versioning.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
@@ -10,8 +11,8 @@
       "semver",
       "semantic versioning"
     ],
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -2,14 +2,15 @@
   "version": "1.0.0-*",
   "description": "SynchronizationTestApp Console Application",
   "authors": [
-    "yigalatz"
+    "yigalatz",
+    "Octopus Deploy"
   ],
   "packOptions": {
     "tags": [
       ""
     ],
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "buildOptions": {

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -1,9 +1,13 @@
 ﻿{
   "version": "3.6.0-*",
+  "authors": [
+    "NuGet",
+    "Octopus Deploy"
+  ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "packOptions": {
-    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+    "licenseUrl": "https://raw.githubusercontent.com/OctopusDeploy/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/OctopusDeploy/NuGet.Client"
   },
   "buildOptions": {
     "warningsAsErrors": true,


### PR DESCRIPTION
Add Octopus Deploy to authors.
Update project url to point to our fork.
Update license url to point to our license file (which has not bene modified since we forked)