### PR TITLE
Re-implement SetOverrideProxySettings

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Proxy/IProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/IProxyCache.cs
@@ -10,5 +10,7 @@ namespace NuGet.Configuration
     {
         void Add(IWebProxy proxy);
         IWebProxy? GetProxy(Uri uri);
+        ICredentials? GetDefaultProxyCredentials();
+        bool UseProxy();
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using NuGet.Common;
 
 namespace NuGet.Configuration
 {
+    [SuppressMessage("Style", "IDE1006:Naming Styles")]
     public class ProxyCache : IProxyCache, IProxyCredentialCache
     {
 #if !IS_CORECLR
@@ -20,6 +22,21 @@ namespace NuGet.Configuration
         /// </summary>
         private static readonly IWebProxy _originalSystemProxy = WebRequest.GetSystemWebProxy();
 #endif
+        /// <summary>
+        /// Octopus overrides the proxy so we can ensure that the credentials are refreshed every time.
+        /// </summary>
+        /// <remarks>
+        /// This was a fix implemented on an older version of NuGet 3.6.1
+        /// https://github.com/OctopusDeploy/Issues/issues/2959
+        /// This fix was rejected https://github.com/NuGet/NuGet.Client/pull/1153
+        /// That lead us to fork and implement this fix.
+        ///
+        /// In updating Octopus to 6.14.x we opted to maintain this fix as a work around.
+        /// </remarks>
+        private IWebProxy? _overrideProxy;
+        private ICredentials? _overrideProxyCredentials;
+        private bool _overrideProxySet;
+
         private readonly ConcurrentDictionary<Uri, ICredentials> _cachedCredentials = new ConcurrentDictionary<Uri, ICredentials>();
 
         private readonly ISettings _settings;
@@ -48,6 +65,18 @@ namespace NuGet.Configuration
 
         public IWebProxy? GetProxy(Uri sourceUri)
         {
+            // Use the override proxy if someone has set it in code
+            if (_overrideProxy != null)
+            {
+                return _overrideProxy;
+            }
+
+            if (_overrideProxySet)
+            {
+                return null;
+            }
+
+            // Original NuGet Code below:
             // Check if the user has configured proxy details in settings or in the environment.
             var configuredProxy = GetUserConfiguredProxy();
             if (configuredProxy != null)
@@ -69,12 +98,45 @@ namespace NuGet.Configuration
             return null;
         }
 
+        /// <summary>
+        /// Get the manually overwritten proxy credentials
+        /// </summary>
+        /// <returns></returns>
+        public ICredentials? GetDefaultProxyCredentials()
+        {
+            return _overrideProxyCredentials;
+        }
+
+        public bool UseProxy()
+        {
+            return _overrideProxySet;
+        }
+
         // Adds new proxy credentials to cache if there's not any in there yet
         private bool TryAddProxyCredentialsToCache(WebProxy configuredProxy)
         {
             // If a proxy was cached, it means the stored credentials are incorrect. Use the cached one in this case.
             var proxyCredentials = configuredProxy.Credentials ?? CredentialCache.DefaultCredentials;
             return _cachedCredentials.TryAdd(configuredProxy.ProxyAddress, proxyCredentials);
+        }
+
+        /// <summary>
+        /// Set the manually overwritten proxy settings(these will be used by various v3 providers)
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var proxy = new WebProxy("http://proxy.com");
+        /// var credentials = new NetworkCredential("username", "password");
+        /// ProxyCache.Instance.SetOverrideProxySettings(proxy, credentials);
+        /// </code>
+        /// </example>
+        /// <param name="proxy"></param>
+        /// <param name="credentials"></param>
+        public void SetOverrideProxySettings(IWebProxy proxy, ICredentials credentials)
+        {
+            _overrideProxy = proxy;
+            _overrideProxyCredentials = credentials;
+            _overrideProxySet = true;
         }
 
         public WebProxy? GetUserConfiguredProxy()

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+NuGet.Configuration.IProxyCache.GetDefaultProxyCredentials() -> System.Net.ICredentials?
+NuGet.Configuration.IProxyCache.UseProxy() -> bool
+NuGet.Configuration.ProxyCache.GetDefaultProxyCredentials() -> System.Net.ICredentials?
+NuGet.Configuration.ProxyCache.SetOverrideProxySettings(System.Net.IWebProxy! proxy, System.Net.ICredentials! credentials) -> void
+NuGet.Configuration.ProxyCache.UseProxy() -> bool

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -18,6 +18,18 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace NuGet.Protocol
 {
+    /// <summary>
+    /// Provides an HttpHandlerResourceV3 for a given package source.
+    /// </summary>
+    /// <remarks>
+    /// HttpHandlerResourceV3Provider
+    ///     ↓ (provides HttpHandlerResource)
+    /// HttpSourceResourceProvider
+    ///     ↓ (uses HttpHandlerResource to create HttpSource)
+    /// HttpSourceResource
+    ///     ↓ (used by all HTTP-based providers)
+    /// All V3 and V2 Resources that need HTTP access
+    /// </remarks>
     public class HttpHandlerResourceV3Provider : ResourceProvider
     {
         private readonly IProxyCache _proxyCache;
@@ -54,15 +66,39 @@ namespace NuGet.Protocol
             return Task.FromResult(new Tuple<bool, INuGetResource>(curResource != null, curResource));
         }
 
+        // To save time of someone coming back to this code later, here is a list of resources that use HttpHandlerResourceV3Provider:
+        //
+        // All V3 Resources that depend on HttpSourceResource - INDIRECT USERS
+        // Based on the grep results, these all call await source.GetResourceAsync<HttpSourceResource>(token):
+        // PackageUpdateResource (via PackageUpdateResourceV3Provider)
+        // RegistrationResourceV3 (via RegistrationResourceV3Provider)
+        // ServiceIndexResourceV3 (via ServiceIndexResourceV3Provider)
+        // PackageSearchResource (via PackageSearchResourceV3Provider)
+        // PackageMetadataResource (via PackageMetadataResourceV3Provider)
+        // DownloadResource (via DownloadResourceV3Provider)
+        // DependencyInfoResource (via DependencyInfoResourceV3Provider)
+        // AutoCompleteResource (via AutoCompleteResourceV3Provider)
+        //
+        // All V2 Resources that depend on HttpSourceResource - INDIRECT USERS
+        // ODataServiceDocumentResourceV2 (via ODataServiceDocumentResourceV2Provider)
+        // Plus all V2 feed providers (search, metadata, download, etc.)
         private HttpHandlerResourceV3 CreateResource(PackageSource packageSource)
         {
             var sourceUri = packageSource.SourceUri;
             var proxy = _proxyCache.GetProxy(sourceUri);
+            var useProxy = _proxyCache.UseProxy();
+#if IS_CORECLR
+            var defaultProxyCredentials = ProxyCache.Instance.GetDefaultProxyCredentials();
+#endif
 
             // replace the handler with the proxy aware handler
             var clientHandler = new HttpClientHandler
             {
+                UseProxy = useProxy,
                 Proxy = proxy,
+#if IS_CORECLR
+                DefaultProxyCredentials = defaultProxyCredentials,
+#endif
                 AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate),
             };
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net;
 using Moq;
 using NuGet.Common;
@@ -146,6 +147,104 @@ namespace NuGet.Configuration.Test
             // Assert
             AssertProxy(host, username, password, proxy);
             Assert.Equal(bypassedAddresses, proxy!.BypassList);
+        }
+
+        [Fact]
+        public void SetOverrideProxySettings_WithValidProxy_SetsOverrideProxy()
+        {
+            // Arrange
+            var settings = Mock.Of<ISettings>();
+            var environment = Mock.Of<IEnvironmentVariableReader>();
+            var proxyCache = new ProxyCache(settings, environment);
+            var proxy = new WebProxy("http://proxy.example.com:8080");
+            var credentials = new NetworkCredential("testuser", "testpass");
+
+            // Act
+            proxyCache.SetOverrideProxySettings(proxy, credentials);
+
+            // Assert
+            var sourceUri = new Uri("http://example.com");
+            var result = proxyCache.GetProxy(sourceUri);
+            Assert.Same(proxy, result);
+            Assert.True(proxyCache.UseProxy());
+            Assert.Same(credentials, proxyCache.GetDefaultProxyCredentials());
+        }
+
+        [Fact]
+        public void GetProxy_WithOverrideProxy_IgnoresSettingsAndEnvironment()
+        {
+            // Arrange
+            var settings = new Mock<ISettings>(MockBehavior.Strict);
+            settings.Setup(s => s.GetSection("config"))
+                .Returns(new VirtualSettingSection("config",
+                    new AddItem("http_proxy", "http://settings.proxy.com")));
+
+            var environment = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
+            environment.Setup(s => s.GetEnvironmentVariable("http_proxy")).Returns("http://env.proxy.com");
+            environment.Setup(s => s.GetEnvironmentVariable("no_proxy")).Returns("");
+
+            var proxyCache = new ProxyCache(settings.Object, environment.Object);
+            var overrideProxy = new WebProxy("http://override.proxy.com");
+            var credentials = new NetworkCredential("user", "pass");
+
+            // Act
+            proxyCache.SetOverrideProxySettings(overrideProxy, credentials);
+            var result = proxyCache.GetProxy(new Uri("http://example.com"));
+
+            // Assert
+            Assert.Same(overrideProxy, result);
+
+            // Verify that settings and environment were not accessed after override was set
+            settings.Verify(s => s.GetSection("config"), Times.Never);
+            environment.Verify(s => s.GetEnvironmentVariable("http_proxy"), Times.Never);
+        }
+
+        [Fact]
+        public void GetDefaultProxyCredentials_WithOverride_ReturnsCredentials()
+        {
+            // Arrange
+            var settings = Mock.Of<ISettings>();
+            var environment = Mock.Of<IEnvironmentVariableReader>();
+            var proxyCache = new ProxyCache(settings, environment);
+            var proxy = new WebProxy("http://proxy.example.com");
+            var credentials = new NetworkCredential("testuser", "testpass");
+
+            // Act
+            proxyCache.SetOverrideProxySettings(proxy, credentials);
+
+            // Assert
+            var result = proxyCache.GetDefaultProxyCredentials();
+            Assert.Same(credentials, result);
+        }
+
+        [Fact]
+        public void SetOverrideProxySettings_Multiple_Times_UpdatesCorrectly()
+        {
+            // Arrange
+            var settings = Mock.Of<ISettings>();
+            var environment = Mock.Of<IEnvironmentVariableReader>();
+            var proxyCache = new ProxyCache(settings, environment);
+
+            var firstProxy = new WebProxy("http://first.proxy.com");
+            var firstCredentials = new NetworkCredential("user1", "pass1");
+            var secondProxy = new WebProxy("http://second.proxy.com");
+            var secondCredentials = new NetworkCredential("user2", "pass2");
+
+            // Act
+            proxyCache.SetOverrideProxySettings(firstProxy, firstCredentials);
+            var firstResult = proxyCache.GetProxy(new Uri("http://example.com"));
+            var firstCreds = proxyCache.GetDefaultProxyCredentials();
+
+            proxyCache.SetOverrideProxySettings(secondProxy, secondCredentials);
+            var secondResult = proxyCache.GetProxy(new Uri("http://example.com"));
+            var secondCreds = proxyCache.GetDefaultProxyCredentials();
+
+            // Assert
+            Assert.Same(firstProxy, firstResult);
+            Assert.Same(firstCredentials, firstCreds);
+            Assert.Same(secondProxy, secondResult);
+            Assert.Same(secondCredentials, secondCreds);
+            Assert.True(proxyCache.UseProxy());
         }
 
         private static void AssertProxy(string proxyAddress, string? username, string? password, WebProxy? actual)


### PR DESCRIPTION
# Background
To support existing functionality within Octopus Deploy we need to re-implement the `SetOverrideProxySettings` method that was implemented on the [old 3.6.1-octopus branch](https://github.com/OctopusDeploy/NuGet.Client/tree/78c8ada1c0fe9e74e482ea0e9b6708a667d5a2e1)

This is a re-implementation of one feature from the [original octopus fork](https://github.com/OctopusDeploy/NuGet.Client/pull/2/commits) specifically this commit ([Adding Better proxy support for .net core](https://github.com/OctopusDeploy/NuGet.Client/pull/2/commits/92c01a0a0f27d180e09a80b6fba7dca244a0b13c))

This was to fix https://github.com/OctopusDeploy/Issues/issues/2926

3.6.1-octopus branch is now out of date and we have opted to re-fork, with the minimum required changes, this is one of them.

# Result

Re-implemented the original ([Adding Better proxy support for .net core](https://github.com/OctopusDeploy/NuGet.Client/pull/2/commits/92c01a0a0f27d180e09a80b6fba7dca244a0b13c)) commit in 6.14.x


# Additional information 

In porting the functionality we have some concerns ([here](https://github.com/OctopusDeploy/NuGet.Client/pull/9#discussion_r2380528581) and [here](https://github.com/OctopusDeploy/NuGet.Client/pull/9#discussion_r2380541182)) with how this is was [originally implemented](https://github.com/OctopusDeploy/NuGet.Client/commit/92c01a0a0f27d180e09a80b6fba7dca244a0b13c#diff-3ee3e857e5b2877a69577e2200606f1bcb8334fa35fc630c3dac4a4a52b6c94bL24-L28).

The primary issue being that if a implementation doesn't call 'ProxyCache.Instance.SetOverrideProxySettings' then `UseProxy` will be false that would lead to the consumers never being able to use a proxy because of the default behavior of `HttpClientHandler`

We have mitigated this issue/risk by ensuring that we don't have any consuming code in our code base that uses NuGet HttpClientHandler and relies on the default behaviour of use proxy (in other words everything we use calls `SetOverrideProxySettings` and thus UseProxy = true)

You are unable to set a proxy, without `SetOverrideProxySettings` setting `useproxy` to true, because it would have thrown an exception, because `HttpClientHandler` throws exception if UseProxy is false and its passed a proxy (IProxyCache's: GetUserConfiguredProxy or GetSystemProxy), so its clear that we never hit this code path with a proxy.
<img width="2723" height="724" alt="image" src="https://github.com/user-attachments/assets/1b5b519c-b91c-4719-9306-5a50b6011926" />


We will do a subsequent PR to address these issues, but for now we will merge the existing code even with the failing test as this test was created after the `3.6.0-octopus` fork was created.