### PR TITLE
Fixed potential bug in SetOverrideProxySettings

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Proxy/IProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/IProxyCache.cs
@@ -11,6 +11,5 @@ namespace NuGet.Configuration
         void Add(IWebProxy proxy);
         IWebProxy? GetProxy(Uri uri);
         ICredentials? GetDefaultProxyCredentials();
-        bool UseProxy();
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
@@ -23,7 +23,7 @@ namespace NuGet.Configuration
         private static readonly IWebProxy _originalSystemProxy = WebRequest.GetSystemWebProxy();
 #endif
         /// <summary>
-        /// Octopus overrides the proxy so we can ensure that the credentials are refreshed every time.
+        /// Octopus overrides the (user or system proxy) with a custom proxy implementation
         /// </summary>
         /// <remarks>
         /// This was a fix implemented on an older version of NuGet 3.6.1
@@ -33,9 +33,8 @@ namespace NuGet.Configuration
         ///
         /// In updating Octopus to 6.14.x we opted to maintain this fix as a work around.
         /// </remarks>
-        private IWebProxy? _overrideProxy;
-        private ICredentials? _overrideProxyCredentials;
-        private bool _overrideProxySet;
+        private IWebProxy? _overrideProxyWithCustomProxy;
+        private ICredentials? _overrideDefaultProxyCredentials;
 
         private readonly ConcurrentDictionary<Uri, ICredentials> _cachedCredentials = new ConcurrentDictionary<Uri, ICredentials>();
 
@@ -63,17 +62,18 @@ namespace NuGet.Configuration
             _environment = environment;
         }
 
+        /// <summary>
+        /// Returns a proxy (if it exists) based on what is set in priority order of:
+        /// Custom proxy, User configured proxy, System proxy, no proxy.
+        /// </summary>
+        /// <param name="sourceUri"></param>
+        /// <returns></returns>
         public IWebProxy? GetProxy(Uri sourceUri)
         {
             // Use the override proxy if someone has set it in code
-            if (_overrideProxy != null)
+            if (_overrideProxyWithCustomProxy is not null)
             {
-                return _overrideProxy;
-            }
-
-            if (_overrideProxySet)
-            {
-                return null;
+                return _overrideProxyWithCustomProxy;
             }
 
             // Original NuGet Code below:
@@ -99,17 +99,13 @@ namespace NuGet.Configuration
         }
 
         /// <summary>
-        /// Get the manually overwritten proxy credentials
+        /// Get the manually overwritten DefaultProxyCredentials.
+        /// for when we don't set the proxy, but we want the default proxy credentials.
         /// </summary>
         /// <returns></returns>
         public ICredentials? GetDefaultProxyCredentials()
         {
-            return _overrideProxyCredentials;
-        }
-
-        public bool UseProxy()
-        {
-            return _overrideProxySet;
+            return _overrideDefaultProxyCredentials;
         }
 
         // Adds new proxy credentials to cache if there's not any in there yet
@@ -121,7 +117,7 @@ namespace NuGet.Configuration
         }
 
         /// <summary>
-        /// Set the manually overwritten proxy settings(these will be used by various v3 providers)
+        /// Override the proxy and default proxy credentials settings
         /// </summary>
         /// <example>
         /// <code>
@@ -130,13 +126,12 @@ namespace NuGet.Configuration
         /// ProxyCache.Instance.SetOverrideProxySettings(proxy, credentials);
         /// </code>
         /// </example>
-        /// <param name="proxy"></param>
-        /// <param name="credentials"></param>
-        public void SetOverrideProxySettings(IWebProxy proxy, ICredentials credentials)
+        /// <param name="proxy">Optional, if not set, default to cache behaviour, user -> system -> no proxy</param>
+        /// <param name="defaultProxyCredentials">This sets the "defaultProxyCredentials" on the HttpClientHandler (its default is null)</param>
+        public void SetOverrideProxySettings(IWebProxy? proxy, ICredentials? defaultProxyCredentials)
         {
-            _overrideProxy = proxy;
-            _overrideProxyCredentials = credentials;
-            _overrideProxySet = true;
+            _overrideProxyWithCustomProxy = proxy;
+            _overrideDefaultProxyCredentials = defaultProxyCredentials;
         }
 
         public WebProxy? GetUserConfiguredProxy()

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -87,6 +87,7 @@ NuGet.Configuration.IPackageSourceProvider.SavePackageSources(System.Collections
 NuGet.Configuration.IPackageSourceProvider.UpdatePackageSource(NuGet.Configuration.PackageSource! source, bool updateCredentials, bool updateEnabled) -> void
 NuGet.Configuration.IProxyCache
 NuGet.Configuration.IProxyCache.Add(System.Net.IWebProxy! proxy) -> void
+NuGet.Configuration.IProxyCache.GetDefaultProxyCredentials() -> System.Net.ICredentials?
 NuGet.Configuration.IProxyCache.GetProxy(System.Uri! uri) -> System.Net.IWebProxy?
 NuGet.Configuration.IProxyCredentialCache
 NuGet.Configuration.IProxyCredentialCache.UpdateCredential(System.Uri! proxyAddress, System.Net.NetworkCredential! credentials) -> void
@@ -221,9 +222,11 @@ NuGet.Configuration.PackageSourceProvider.UpdatePackageSource(NuGet.Configuratio
 NuGet.Configuration.ProxyCache
 NuGet.Configuration.ProxyCache.Add(System.Net.IWebProxy? proxy) -> void
 NuGet.Configuration.ProxyCache.GetCredential(System.Uri! proxyAddress, string! authType) -> System.Net.NetworkCredential?
+NuGet.Configuration.ProxyCache.GetDefaultProxyCredentials() -> System.Net.ICredentials?
 NuGet.Configuration.ProxyCache.GetProxy(System.Uri! sourceUri) -> System.Net.IWebProxy?
 NuGet.Configuration.ProxyCache.GetUserConfiguredProxy() -> NuGet.Configuration.WebProxy?
 NuGet.Configuration.ProxyCache.ProxyCache(NuGet.Configuration.ISettings! settings, NuGet.Common.IEnvironmentVariableReader! environment) -> void
+NuGet.Configuration.ProxyCache.SetOverrideProxySettings(System.Net.IWebProxy? proxy, System.Net.ICredentials? defaultProxyCredentials) -> void
 NuGet.Configuration.ProxyCache.UpdateCredential(System.Uri! proxyAddress, System.Net.NetworkCredential! credentials) -> void
 NuGet.Configuration.ProxyCache.Version.get -> System.Guid
 NuGet.Configuration.RepositoryItem

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-NuGet.Configuration.IProxyCache.GetDefaultProxyCredentials() -> System.Net.ICredentials?
-NuGet.Configuration.IProxyCache.UseProxy() -> bool
-NuGet.Configuration.ProxyCache.GetDefaultProxyCredentials() -> System.Net.ICredentials?
-NuGet.Configuration.ProxyCache.SetOverrideProxySettings(System.Net.IWebProxy! proxy, System.Net.ICredentials! credentials) -> void
-NuGet.Configuration.ProxyCache.UseProxy() -> bool

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -86,7 +86,6 @@ namespace NuGet.Protocol
         {
             var sourceUri = packageSource.SourceUri;
             var proxy = _proxyCache.GetProxy(sourceUri);
-            var useProxy = _proxyCache.UseProxy();
 #if IS_CORECLR
             var defaultProxyCredentials = ProxyCache.Instance.GetDefaultProxyCredentials();
 #endif
@@ -94,7 +93,6 @@ namespace NuGet.Protocol
             // replace the handler with the proxy aware handler
             var clientHandler = new HttpClientHandler
             {
-                UseProxy = useProxy,
                 Proxy = proxy,
 #if IS_CORECLR
                 DefaultProxyCredentials = defaultProxyCredentials,

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTests.cs
@@ -166,7 +166,6 @@ namespace NuGet.Configuration.Test
             var sourceUri = new Uri("http://example.com");
             var result = proxyCache.GetProxy(sourceUri);
             Assert.Same(proxy, result);
-            Assert.True(proxyCache.UseProxy());
             Assert.Same(credentials, proxyCache.GetDefaultProxyCredentials());
         }
 
@@ -244,7 +243,6 @@ namespace NuGet.Configuration.Test
             Assert.Same(firstCredentials, firstCreds);
             Assert.Same(secondProxy, secondResult);
             Assert.Same(secondCredentials, secondCreds);
-            Assert.True(proxyCache.UseProxy());
         }
 
         private static void AssertProxy(string proxyAddress, string? username, string? password, WebProxy? actual)


### PR DESCRIPTION
# Background

As apart of [Re-implement SetOverrideProxySettings ](https://github.com/OctopusDeploy/NuGet.Client/pull/9) we re-introduced the old commit that would allow us to set a custom proxy and set default credentials based on our own configuration.  Originally to fix: https://github.com/OctopusDeploy/Issues/issues/2926

This implementation had a issue that would mean in other usages (outside of our use case) it would [throw an exception if you used a proxy (more details in pr description too) ](https://github.com/OctopusDeploy/NuGet.Client/pull/9#discussion_r2380528581) because it was returning `false` for `UseProxy` by default if you didnt call `SetOverrideProxySettings`

It didn't directly effect us as we always `SetOverrideProxySettings` in our usages of this proxycache that would mean its always `true` for us, but it wasn't worth leaving in the codebase to confuse someone in the future.

# Results

Removed `UseProxy` from the proxy cache (as it wasn't a actual configuration option from our consumer, and instead it was inferred), and [instead rely on the default `HttpClientHandler` behavior that sets it to `true`](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclienthandler.useproxy?view=net-9.0#property-value)

Also renamed `_overrideProxyCredentials` -> `_overrideDefaultProxyCredentials` to be more clear that its to be treated differently to the `_overrideProxyWithCustomProxy` that i also re-named to make it clear that this is really a 'third' option for the proxy.

This will mean the `IProxyCache.GetProxy` hierarchy is now (depending on configuration): 
1. Custom Proxy
2. User Proxy
3. System Proxy
4. No Proxy