### PR TITLE
Fix incorrect reference when creating release from action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,4 +202,20 @@ jobs:
         with:
           project: Nuget.Client
           release_number: ${{ env.PACKAGE_VERSION }}
-          package_version: ${{ env.PACKAGE_VERSION }}
+          # Packages docs:
+          # Format: StepName:Version or PackageID:Version or StepName:PackageName:Version.
+          # We specifically target the package name of NuGet.CommandLine/SourcePackage because our step uses both
+          # - SourcePackage = ${{ env.PACKAGE_VERSION }} === 6.14.0-release.213 (this is StepName:PackageName:Version)
+          # - Nuget.CommandLine = 6.14.0 (this not listed here will resolve to its PackageID)
+          packages: |
+            Package Push - NuGet.CommandLine:SourcePackage:${{ env.PACKAGE_VERSION }}
+            *:NuGet.Common:${{ env.PACKAGE_VERSION }}
+            *:NuGet.Configuration:${{ env.PACKAGE_VERSION }}
+            *:NuGet.Frameworks:${{ env.PACKAGE_VERSION }}
+            *:NuGet.Packaging:${{ env.PACKAGE_VERSION }}
+            *:NuGet.Protocol:${{ env.PACKAGE_VERSION }}
+            *:NuGet.Versioning:${{ env.PACKAGE_VERSION }}
+            *:NuGet.PackageManagement:${{ env.PACKAGE_VERSION }}
+            *:NuGet.Build.Tasks:${{ env.PACKAGE_VERSION }}
+            *:NuGet.Commands:${{ env.PACKAGE_VERSION }}
+            *:NuGet.Resolver:${{ env.PACKAGE_VERSION }}


### PR DESCRIPTION
# Background
When we 'create a release' it is specifying the package version against the "PackageId" However this causes a conflict when we create the release as it gets confused with the `packageId` and `packageName` and sets the pre-release build for "all" package references, not just the one it requires.

This caused this error:

<img width="2404" height="173" alt="image" src="https://github.com/user-attachments/assets/fc5368ba-3e52-4ff4-90fe-054e8d9c1d99" />

But when we create a release manually from the UI is presents:
<img width="2500" height="276" alt="image" src="https://github.com/user-attachments/assets/27fbe021-1737-41a2-afdd-e089e7de5c39" />

And validate the correct versions, i suspect that our release config is currently setting `Package Push - NuGet.CommandLine/NuGet.CommandLine` to `${{ env.PACKAGE_VERSION }}` as it shares the same `PackageId`

According to the docs, you can specify a PackageName or the PackageId

# Results 
I suspect that changing to specify the `SourcePackage` PackageName instead of Package Id, it should only set the `Package Push - NuGet.CommandLine/SourcePackage` to  `${{ env.PACKAGE_VERSION }}` 

# Reducing Risk
I can confirm the [github action from this pr](https://github.com/OctopusDeploy/NuGet.Client/actions/runs/18082849580/job/51448848101) did a successful release
<img width="1270" height="509" alt="image" src="https://github.com/user-attachments/assets/9fac8955-578b-4ab8-99e7-4414e3ced771" />

 