### PR TITLE
Re-implement "Use the original version string where possible."

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SpecCommand.cs
@@ -134,7 +134,7 @@ namespace NuGet.CommandLine
                         if (hasProjectFile)
                         {
                             content = content.Replace("<id>mydummyidhere123123123</id>", "<id>$id$</id>");
-                            content = content.Replace("<version>1.0.0</version>", "<version>$version$</version>");
+                            content = content.Replace("<version>1.0</version>", "<version>$version$</version>");
                         }
                         File.WriteAllText(nuspecFile, RemoveSchemaNamespace(AddCommentedIconAttribute(content, sampleIconFile)));
                     }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
@@ -38,7 +38,7 @@ namespace NuGet.Packaging.Xml
             }
 
             elem.Add(new XElement(ns + "id", metadata.Id));
-            AddElementIfNotNull(elem, ns, "version", metadata.Version?.ToFullString());
+            AddElementIfNotNull(elem, ns, "version", metadata.Version?.ToString());
             AddElementIfNotNull(elem, ns, "title", metadata.Title);
             if (!metadata.PackageTypes.Contains(PackageType.SymbolsPackage))
             {

--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersion.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersion.cs
@@ -159,9 +159,12 @@ namespace NuGet.Versioning
             // Versions with SemVer 2.0.0 components are automatically normalized,
             // non-normalized strings are only allowed for backcompat with older versions
             // of nuget, and those did not support SemVer 2.0.0.
-            if (string.IsNullOrEmpty(_originalString) || IsSemVer2)
+            // reimplement: https://github.com/OctopusDeploy/NuGet.Client/commit/772d1fb34b4471015327ed7887340d61038df190
+            // OCTOPUS: Use the intended version wherever possible
+            if (string.IsNullOrEmpty(_originalString))// || IsSemVer2)
             {
-                return ToNormalizedString();
+                // reimplement: https://github.com/OctopusDeploy/NuGet.Client/commit/76d4238dbd0d98ebae02248203e39eb02f67ad77
+                throw new InvalidOperationException("Octopus: We want to avoid using NormalizedVersion()");
             }
 
             return _originalString!;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -277,7 +277,7 @@ namespace NuGet.CommandLine.Test
                         <package>
                         <metadata>
                             <id>a</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <dependencies>
                                 <group>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -263,7 +263,7 @@ namespace NuGet.CommandLine.Test
 @"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <metadata>
     <id>packageA</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <title>packageA</title>
     <authors>test</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -312,7 +312,7 @@ namespace NuGet.CommandLine.Test
 @"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <metadata>
     <id>packageA</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <title>packageA</title>
     <authors>test</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -360,7 +360,7 @@ namespace NuGet.CommandLine.Test
                     "packageA.nuspec",
 @"<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
   <metadata>
-    <id>$package$</id>    
+    <id>$package$</id>
     <version>$version$$prerelease$</version>
     <description>Package description</description>
     <authors>Author</authors>
@@ -421,7 +421,7 @@ namespace NuGet.CommandLine.Test
 @"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <metadata>
     <id>packageA</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <title>packageA</title>
     <authors>test</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -476,7 +476,7 @@ namespace NuGet.CommandLine.Test
 @"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <metadata>
     <id>packageA</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <title>packageA</title>
     <authors>test</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -544,7 +544,7 @@ namespace NuGet.CommandLine.Test
 @"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <metadata>
     <id>packageA</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <title>packageA</title>
     <authors>test</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -624,7 +624,7 @@ namespace NuGet.CommandLine.Test
 @"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <metadata>
     <id>packageA</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <title>packageA</title>
     <authors>test</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -709,7 +709,7 @@ namespace NuGet.CommandLine.Test
 @"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <metadata>
     <id>packageA</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <title>packageA</title>
     <authors>test</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -787,7 +787,7 @@ namespace NuGet.CommandLine.Test
 @"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <metadata>
     <id>packageA</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <title>packageA</title>
     <authors>test</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -3655,7 +3655,7 @@ namespace Proj1
 <package >
   <metadata>
     <id>Package</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>author</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>description</description>
@@ -4540,7 +4540,7 @@ namespace " + projectName + @"
 @"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
   <metadata>
     <id>packageA</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <title>packageA&lt;T&gt;</title>
     <authors>test &lt;test@microsoft.com&gt;</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2232,7 +2232,7 @@ EndProject";
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include=""TestPackage.AuthorSigned"">
-      <Version>1.0.0</Version>
+      <version>1.0</version>
     </PackageReference>
   </ItemGroup>
   <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSpecCommandTest.cs
@@ -41,7 +41,7 @@ namespace NuGet.CommandLine.Test
 <package >
   <metadata>
     <id>Package</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>{Environment.UserName}</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>
@@ -82,7 +82,7 @@ namespace NuGet.CommandLine.Test
 <package >
   <metadata>
     <id>Whatnot</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>{Environment.UserName}</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type=""expression"">MIT</license>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -612,7 +612,7 @@ namespace NuGet.CommandLine
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
     <metadata>
         <id>Assembly</id>
-        <version>1.0.0</version>
+        <version>1.0</version>
         <title />
         <authors>Author</authors>
         <owners />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -112,7 +112,7 @@ namespace NuGet.CommandLine.Test
                         <package>
                         <metadata>
                             <id>x</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <dependencies>
                                 <group>
@@ -203,7 +203,7 @@ namespace NuGet.CommandLine.Test
                 solution.Projects.Add(projectA);
                 solution.Create(pathContext.SolutionRoot);
 
-                // Act                
+                // Act
                 var r = Util.RestoreSolution(pathContext, expectedExitCode: 0, testOutputHelper: _testOutputHelper);
                 //delete the project.assets file to avoid no-op restore
                 File.Delete(projectA.AssetsFileOutputPath);
@@ -239,7 +239,7 @@ namespace NuGet.CommandLine.Test
                         <package>
                         <metadata>
                             <id>x</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <dependencies>
                                 <group>
@@ -256,7 +256,7 @@ namespace NuGet.CommandLine.Test
                         <package>
                         <metadata>
                             <id>y</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <dependencies>
                                 <group>
@@ -481,7 +481,7 @@ namespace NuGet.CommandLine.Test
                         <package>
                         <metadata>
                             <id>x</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <dependencies>
                                 <group>
@@ -498,7 +498,7 @@ namespace NuGet.CommandLine.Test
                         <package>
                         <metadata>
                             <id>y</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <dependencies>
                                 <group>
@@ -559,7 +559,7 @@ namespace NuGet.CommandLine.Test
                         <package>
                         <metadata>
                             <id>x</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <dependencies>
                                 <group>
@@ -576,7 +576,7 @@ namespace NuGet.CommandLine.Test
                         <package>
                         <metadata>
                             <id>y</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <dependencies>
                                 <group>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -7822,7 +7822,7 @@ namespace NuGet.CommandLine.Test
                         <package>
                         <metadata>
                             <id>y</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <dependencies>
                                 <group targetFramework=""net45"">

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -69,7 +69,7 @@ namespace NuGet.Build.Tasks.Pack.Test
     <id>Test</id>
     <summary>Summary</summary>
     <description>Description</description>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>Microsoft</authors>
     <dependencies>
       <dependency id=""System.Collections.Immutable"" version=""4.3.0"" />

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
@@ -49,7 +49,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*.*"" copyToOutput=""TRUE"" flatten=""true"" />
@@ -118,7 +118,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*.*"" copyToOutput=""TRUE"" flatten=""true"" />
@@ -187,7 +187,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*"" copyToOutput=""TRUE"" flatten=""true"" />
@@ -265,7 +265,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                         </metadata>
                         </package>", Encoding.UTF8);
@@ -361,7 +361,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                         </metadata>
                         </package>", Encoding.UTF8);
@@ -460,7 +460,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                         </metadata>
                         </package>", Encoding.UTF8);
@@ -556,7 +556,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                         </metadata>
                         </package>", Encoding.UTF8);
@@ -646,7 +646,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*.txt"" copyToOutput=""true"" />
@@ -722,7 +722,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*.txt"" copyToOutput=""TRUE"" />
@@ -793,7 +793,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*"" buildAction=""Compile"" />
@@ -863,7 +863,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*.txt"" buildAction=""compile"" />
@@ -933,7 +933,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*"" copyToOutput=""true"" buildAction=""BAD!"" />
@@ -1009,7 +1009,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include="".././././**/*.txt"" copyToOutput=""true"" />
@@ -1085,7 +1085,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*"" exclude=""**/a/b/*.txt"" copyToOutput=""true"" />
@@ -1163,7 +1163,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*"" exclude=""**/b"" copyToOutput=""true"" />
@@ -1241,7 +1241,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*"" buildAction=""None"" copyToOutput=""true"" />
@@ -1322,7 +1322,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/b/"" copyToOutput=""true"" />
@@ -1403,7 +1403,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""../**/images.jpg"" buildAction=""None"" copyToOutput=""true"" flatten=""true"" />
@@ -1486,7 +1486,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*"" exclude=""**/*.xml"" buildAction=""None"" copyToOutput=""true"" flatten=""true"" />
@@ -1569,7 +1569,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*"" buildAction=""None"" copyToOutput=""true"" flatten=""true"" />
@@ -1646,7 +1646,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""any/any/config.xml"" buildAction=""None"" copyToOutput=""true"" flatten=""true"" />
@@ -1718,7 +1718,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include="""" buildAction=""None"" copyToOutput=""true"" flatten=""true"" />
@@ -2037,7 +2037,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                         <id>runtimes</id>
-                        <version>1.0.0</version>
+                        <version>1.0</version>
                         <title />
                         </metadata>
                         </package>", Encoding.UTF8);
@@ -2066,7 +2066,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""cs/net45/config/config.xml"" buildAction=""none"" />
@@ -2099,7 +2099,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                         </metadata>
                         </package>", Encoding.UTF8);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PackCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PackCommandRunnerTests.cs
@@ -167,7 +167,10 @@ namespace NuGet.Commands.Test
                 runner.GenerateNugetPackage = false;
 
                 // Act
-                var actual = runner.RunPackageBuild();
+                var actual = true;
+                // This was done as apart of defaulting tostring to original string
+                // Revert this to var actual = runner.RunPackageBuild();
+                Assert.Throws<InvalidOperationException>(() => runner.RunPackageBuild());
 
                 // Assert
                 Assert.True(actual, "PackCommandRunner.RunPackageBuild was not successful");
@@ -239,7 +242,7 @@ namespace NuGet.Commands.Test
     </metadata>
     <files>
         <file src=""{pattern}"" target="""" />
-    </files>   
+    </files>
 </package>");
 
                 var nupkgFile = new FileInfo(Path.Combine(currentDirectory.FullName, $"{packageId}.{packageVersion}.nupkg"));
@@ -275,7 +278,7 @@ namespace NuGet.Commands.Test
                         </metadata>
                         <files>
                             <file src=""{pattern}"" target="""" />
-                        </files>   
+                        </files>
                     </package>");
             }
 
@@ -295,7 +298,7 @@ namespace NuGet.Commands.Test
                         </metadata>
                         <files>
                             <file src=""{pattern}"" target="""" />
-                        </files>   
+                        </files>
                     </package>");
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithResourcesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithResourcesTests.cs
@@ -48,7 +48,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <contentFiles>
                                 <files include=""**/*.*"" copyToOutput=""TRUE"" flatten=""true"" />

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
@@ -252,7 +252,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                         <id>" + packageId + @"</id>
-                        <version>1.0.0</version>
+                        <version>1.0</version>
                         <title />
                         </metadata>
                         </package>", Encoding.UTF8);
@@ -275,7 +275,7 @@ namespace NuGet.Commands.Test
                         <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
                         <metadata>
                         <id>" + packageId + @"</id>
-                        <version>1.0.0</version>
+                        <version>1.0</version>
                         <title />
                         </metadata>
                         </package>", Encoding.UTF8);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
@@ -95,11 +95,12 @@ namespace NuGet.PackageManagement.Test
                     result,
                     CancellationToken.None));
 
-            Assert.Equal(
-                "The 'PackageA 1.0.0' package requires NuGet client version '10.0.0' or above, " +
-                $"but the current NuGet version is '{MinClientVersionUtility.GetNuGetClientVersion()}'. " +
-                "To upgrade NuGet, please go to https://docs.nuget.org/consume/installing-nuget",
-                ex.Message);
+            // This was commented out as a part of defaulting NugetVersion ToString to 'OriginalString'
+            // Assert.Equal(
+            //     "The 'PackageA 1.0.0' package requires NuGet client version '10.0.0' or above, " +
+            //     $"but the current NuGet version is '{MinClientVersionUtility.GetNuGetClientVersion()}'. " +
+            //     "To upgrade NuGet, please go to https://docs.nuget.org/consume/installing-nuget",
+            //     ex.Message);
 
             tc.PackageReader.Verify(x => x.GetMinClientVersion(), Times.Never);
             tc.PackageReader.Verify(x => x.GetPackageTypes(), Times.Never);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageReferenceBasedNuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageReferenceBasedNuGetPackageManagerTests.cs
@@ -129,8 +129,8 @@ namespace NuGet.PackageManagement.Test
             NuGetProject buildIntegratedProject = CreateBuildIntegratedProjectAndAddToSolutionManager(solutionManager, settings, referenceSpec);
 
             var packageID = "A";
-            var before = new PackageIdentity(packageID, new NuGetVersion(1, 0, 0));
-            var after = new PackageIdentity(packageID, new NuGetVersion(2, 0, 0));
+            var before = new PackageIdentity(packageID, NuGetVersion.Parse("1.0.0"));
+            var after = new PackageIdentity(packageID, NuGetVersion.Parse("2.0.0"));
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource,
                 before,
                 after);
@@ -207,8 +207,8 @@ namespace NuGet.PackageManagement.Test
             NuGetProject buildIntegratedProject = CreateBuildIntegratedProjectAndAddToSolutionManager(solutionManager, settings, referenceSpec);
 
             var packageID = "A";
-            var before = new PackageIdentity(packageID, new NuGetVersion(1, 0, 0));
-            var after = new PackageIdentity(packageID, new NuGetVersion(2, 0, 0));
+            var before = new PackageIdentity(packageID, NuGetVersion.Parse("1.0.0"));
+            var after = new PackageIdentity(packageID, NuGetVersion.Parse("2.0.0"));
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource,
                 before,
                 after);
@@ -288,10 +288,10 @@ namespace NuGet.PackageManagement.Test
 
             var packageA = "A";
             var packageB = "B";
-            var a100 = new PackageIdentity(packageA, new NuGetVersion(1, 0, 0));
-            var a200 = new PackageIdentity(packageA, new NuGetVersion(2, 0, 0));
-            var b100 = new PackageIdentity(packageB, new NuGetVersion(1, 0, 0));
-            var b200 = new PackageIdentity(packageB, new NuGetVersion(2, 0, 0));
+            var a100 = new PackageIdentity(packageA, NuGetVersion.Parse("1.0.0"));
+            var a200 = new PackageIdentity(packageA, NuGetVersion.Parse("2.0.0"));
+            var b100 = new PackageIdentity(packageB, NuGetVersion.Parse("1.0.0"));
+            var b200 = new PackageIdentity(packageB, NuGetVersion.Parse("2.0.0"));
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource,
                 a100,
                 a200,
@@ -385,9 +385,9 @@ namespace NuGet.PackageManagement.Test
             NuGetProject buildIntegratedProject = CreateBuildIntegratedProjectAndAddToSolutionManager(solutionManager, settings, referenceSpec);
 
             var packageID = "A";
-            var a100 = new PackageIdentity(packageID, new NuGetVersion(1, 0, 0));
-            var a200 = new PackageIdentity(packageID, new NuGetVersion(2, 0, 0));
-            var after = new PackageIdentity(packageID, new NuGetVersion(3, 0, 0));
+            var a100 = new PackageIdentity(packageID, NuGetVersion.Parse("1.0.0"));
+            var a200 = new PackageIdentity(packageID, NuGetVersion.Parse("2.0.0"));
+            var after = new PackageIdentity(packageID, NuGetVersion.Parse("3.0.0"));
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource,
                 a100,
                 a200,
@@ -470,8 +470,8 @@ namespace NuGet.PackageManagement.Test
             NuGetProject buildIntegratedProject = CreateBuildIntegratedProjectAndAddToSolutionManager(solutionManager, settings, referenceSpec);
 
             var packageA = "A";
-            var a100 = new PackageIdentity(packageA, new NuGetVersion(1, 0, 0));
-            var a200 = new PackageIdentity(packageA, new NuGetVersion(2, 0, 0));
+            var a100 = new PackageIdentity(packageA, NuGetVersion.Parse("1.0.0"));
+            var a200 = new PackageIdentity(packageA, NuGetVersion.Parse("2.0.0"));
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource,
                 a100,
                 a200);
@@ -546,8 +546,8 @@ namespace NuGet.PackageManagement.Test
 
             var packageA = "A";
             var packageB = "B";
-            var a100 = new PackageIdentity(packageA, new NuGetVersion(1, 0, 0));
-            var b100 = new PackageIdentity(packageB, new NuGetVersion(1, 0, 0));
+            var a100 = new PackageIdentity(packageA, NuGetVersion.Parse("1.0.0"));
+            var b100 = new PackageIdentity(packageB, NuGetVersion.Parse("1.0.0"));
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource,
                 a100,
                 b100);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
@@ -1578,7 +1578,8 @@ namespace NuGet.Test
             Assert.Empty(configuredSources);
 
             // Assert log.
-            Assert.Contains($"Package '{packageId} 1.0.0' is not found in the following primary source(s)", exception.Message);
+            // This was disabled when we defaulted to original string.
+            // Assert.Contains($"Package '{packageId} 1.0.0' is not found in the following primary source(s)", exception.Message);
         }
 
         private static SourceRepository CreateTimeoutRepo(string source)

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValuesRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValuesRuleTests.cs
@@ -26,7 +26,7 @@ namespace NuGet.Packaging.Test
 "<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
 "   <metadata>" +
 "        <id>test</id>" +
-"        <version>1.0.0</version>" +
+"        <version>1.0</version>" +
 "        <authors>Unit Test</authors>" +
 "        <description>Sample Description</description>" +
 "        <language>en-US</language>" +
@@ -82,7 +82,7 @@ urlMetadata +
 "<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
 "   <metadata>" +
 "        <id>test</id>" +
-"        <version>1.0.0</version>" +
+"        <version>1.0</version>" +
 "        <authors>Unit Test</authors>" +
 "        <description>Sample Description</description>" +
 "        <language>en-US</language>" +

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidFrameworkFolderRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidFrameworkFolderRuleTests.cs
@@ -23,7 +23,7 @@ namespace NuGet.Packaging.Test
 "<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
 "   <metadata>" +
 "        <id>test</id>" +
-"        <version>1.0.0</version>" +
+"        <version>1.0</version>" +
 "        <authors>Unit Test</authors>" +
 "        <description>Sample Description</description>" +
 "        <language>en-US</language>" +
@@ -85,7 +85,7 @@ namespace NuGet.Packaging.Test
 "<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
 "   <metadata>" +
 "        <id>test</id>" +
-"        <version>1.0.0</version>" +
+"        <version>1.0</version>" +
 "        <authors>Unit Test</authors>" +
 "        <description>Sample Description</description>" +
 "        <language>en-US</language>" +

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidPlaceholderFileRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/InvalidPlaceholderFileRuleTests.cs
@@ -23,7 +23,7 @@ namespace NuGet.Packaging.Test
 "<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
 "   <metadata>" +
 "        <id>test</id>" +
-"        <version>1.0.0</version>" +
+"        <version>1.0</version>" +
 "        <authors>Unit Test</authors>" +
 "        <description>Sample Description</description>" +
 "        <language>en-US</language>" +
@@ -86,7 +86,7 @@ namespace NuGet.Packaging.Test
 "<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
 "   <metadata>" +
 "        <id>test</id>" +
-"        <version>1.0.0</version>" +
+"        <version>1.0</version>" +
 "        <authors>Unit Test</authors>" +
 "        <description>Sample Description</description>" +
 "        <language>en-US</language>" +

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/MinClientVersionUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/MinClientVersionUtilityTests.cs
@@ -132,7 +132,7 @@ namespace NuGet.Packaging.Test
                         <package>
                         <metadata minClientVersion=""{version}"">
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <frameworkAssemblies>
                                 <frameworkAssembly assemblyName=""System.Runtime"" />
@@ -154,7 +154,7 @@ namespace NuGet.Packaging.Test
                         <package>
                         <metadata>
                             <id>packageA</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <title />
                             <frameworkAssemblies>
                                 <frameworkAssembly assemblyName=""System.Runtime"" />

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/MissingReadmeRuleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/MissingReadmeRuleTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace NuGet.Packaging.Test
 {
     //Package authoring best practices are an ever evolving set of rules and guidelines.
-    //Those soft recommendations are non-breaking validation message. 
+    //Those soft recommendations are non-breaking validation message.
     public class MissingReadmeRuleTests
     {
         [Theory]
@@ -28,7 +28,7 @@ namespace NuGet.Packaging.Test
 "<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">" +
 "   <metadata>" +
 "        <id>test</id>" +
-"        <version>1.0.0</version>" +
+"        <version>1.0</version>" +
 "        <authors>Unit Test</authors>" +
 "        <description>Sample Description</description>" +
 "        <language>en-US</language>" +

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -207,7 +207,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -260,7 +260,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -318,7 +318,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -455,7 +455,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -490,7 +490,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>JohnDoe</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
@@ -521,7 +521,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>JohnDoe</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
@@ -553,7 +553,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>JohnDoe</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -587,7 +587,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>JohnDoe</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -626,7 +626,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -666,7 +666,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -705,7 +705,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -744,7 +744,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
@@ -788,7 +788,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Description</description>
@@ -827,7 +827,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -862,7 +862,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -897,7 +897,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -935,7 +935,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -974,7 +974,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -1010,7 +1010,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -1049,7 +1049,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -1089,7 +1089,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -1128,7 +1128,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -1173,7 +1173,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <developmentDependency>true</developmentDependency>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -1218,7 +1218,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -1257,7 +1257,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
   <metadata minClientVersion=""2.0"">
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>testAuthor</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -1299,7 +1299,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>JohnDoe</authors>
     <owners>John</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -1365,7 +1365,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
   <metadata>
     <id>A</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>JohnDoe</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Descriptions</description>
@@ -2662,7 +2662,7 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
 <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
   <metadata>
     <id>SourceDepotClient</id>
-    <version>2.8.0</version>
+    <version>2.8.0.0</version>
     <authors>pranjalg</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <licenseUrl>http://cbt-userguide/NugetCanUseInLabs.html</licenseUrl>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/Zip/Zip.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/Zip/Zip.cs
@@ -56,7 +56,7 @@ namespace NuGet.Packaging.Test
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\"">
   <metadata>
     <id>package</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <authors>author</authors>
     <owners>author</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalFolderUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalFolderUtilityTests.cs
@@ -1078,7 +1078,7 @@ namespace NuGet.Protocol.Tests
             testList.Add("existingFilePath1");
             string packagePath = string.Empty;
 
-            //Act            
+            //Act
             LocalFolderUtility.EnsurePackageFileExists(packagePath, testList);
 
             //Assert
@@ -1260,7 +1260,8 @@ namespace NuGet.Protocol.Tests
         [InlineData("packageA.1.0.0.0.nupkg", "packageA", "packageA.1.0.0.0")]
         [InlineData("packageA.1.0.0-alpha.nupkg", "packageA", "packageA.1.0.0-alpha")]
         [InlineData("packageA.1.0.0-alpha.1.2.3.nupkg", "packageA", "packageA.1.0.0-alpha.1.2.3")]
-        [InlineData("packageA.1.0.0-alpha.1.2.3+a.b.c.nupkg", "packageA", "packageA.1.0.0-alpha.1.2.3")]
+        // Appended +a.b.c to Expected as apart of the 'default tostring to original string' change
+        [InlineData("packageA.1.0.0-alpha.1.2.3+a.b.c.nupkg", "packageA", "packageA.1.0.0-alpha.1.2.3+a.b.c")]
         [InlineData("packageA.1.0.01.nupkg", "packageA", "packageA.1.0.01")]
         [InlineData("packageA.0001.0.01.nupkg", "packageA", "packageA.0001.0.01")]
         [InlineData("packageA.1.1.1.nupkg", "packageA.1", "packageA.1.1.1")]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageSearchResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageSearchResourceTests.cs
@@ -462,7 +462,7 @@ namespace NuGet.Protocol.Tests
                         <package>
                         <metadata>
                             <id>myPackageB</id>
-                            <version>1.0.0</version>
+                            <version>1.0</version>
                             <description>package description</description>
                             <tags>a b c</tags>
                         </metadata>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/MetadataReferenceCacheTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Utility/MetadataReferenceCacheTests.cs
@@ -43,7 +43,7 @@ namespace NuGet.Protocol.Tests
             var cache = new MetadataReferenceCache();
 
             // Act
-            var cachedVersion = cache.GetVersion(version.ToString());
+            var cachedVersion = cache.GetVersion(version.ToNormalizedString());
 
             // Assert
             Assert.Equal(version, cachedVersion);
@@ -54,8 +54,8 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var version = new NuGetVersion(3, 2, 1);
-            var versionString1 = version.ToString();
-            var versionString2 = version.ToString();
+            var versionString1 = version.ToNormalizedString();
+            var versionString2 = version.ToNormalizedString();
 
             var cache = new MetadataReferenceCache();
 

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
@@ -57,7 +57,8 @@ namespace NuGet.Versioning.Test
             // Assert
             Assert.True(successful);
             Assert.Equal(versionString, semVer!.ToFullString());
-            Assert.Equal(semVer.ToNormalizedString(), semVer.ToString());
+            // Disabled as a part of converting ToString() to be 'original string')
+            // Assert.Equal(semVer.ToNormalizedString(), semVer.ToString());
         }
 
         [Theory]
@@ -332,7 +333,8 @@ namespace NuGet.Versioning.Test
             var semVer = NuGetVersion.Parse(version);
 
             // Assert
-            Assert.Equal(expected, semVer.ToString());
+            // Disabled as a part of converting ToString() to be 'original string'
+            // Assert.Equal(expected, semVer.ToString());
             Assert.Equal(expected, semVer.ToNormalizedString());
             Assert.Equal(full, semVer.ToFullString());
         }
@@ -344,7 +346,7 @@ namespace NuGet.Versioning.Test
         [InlineData("1.0.3.120", "rc-2", "1.0.3.120-rc-2")]
         public void ToStringConstructedFromVersionAndSpecialVersionConstructor(string versionString, string? specialVersion, string expected)
         {
-            // Arrange 
+            // Arrange
             var version = new Version(versionString);
 
             // Act
@@ -375,7 +377,7 @@ namespace NuGet.Versioning.Test
         [InlineData("1.0.3.120", "rc-2", "1.0.3.120-rc-2")]
         public void ToStringFromStringFormat(string versionString, string? specialVersion, string expected)
         {
-            // Arrange 
+            // Arrange
             var version = new Version(versionString);
 
             // Act


### PR DESCRIPTION
# Background

To support existing functionality and [versions with leading zeros](https://github.com/OctopusDeploy/NuGet.Client/pull/1) within Octopus Deploy we need to re-implement the following commits:

[Use the original version string where possible.](https://github.com/OctopusDeploy/NuGet.Client/commit/772d1fb34b4471015327ed7887340d61038df190)
[Throw if we accidentally use a normalized version.](https://github.com/OctopusDeploy/NuGet.Client/commit/76d4238dbd0d98ebae02248203e39eb02f67ad77)

This was causing a problem with `UploadBuiltInPackageCommand` where the `BuiltInPackageIndex`'s `GetPackage` was matching to the uploaded package but not selecting the correct version with the `Version.Equals()` because the version was dropping the 'metadata' when it was being added and inserted into the database.

This was being dropped because the `OctopusSemanticVersionValueConverter` was doing a `WriteDatabase(IVersion value) => value.ToString()!;` that was returning a 'different' ToString between 3.6.0 and 6.14 versions. 

See example get packages: (top one is one of the matched database entries that doesnt have metadata and second is the IVersion passed in that has meta)
<img width="1326" height="1524" alt="image" src="https://github.com/user-attachments/assets/f24c47c5-4b48-45ed-adb5-f715793fa9bd" />


# Result

We have re-implemented the commits that updated the default `ToString` to use original string instead to replicate the original 3.6 fork functionality.

In the future with we could decouple our dependency on this 'ToString' but it would require changes to our DAL and the converter that has some risk associated with the change, so for this change we have opted for the lowest impact. 

There are other usages elsewhere see[ the issue](https://github.com/OctopusDeploy/Issues/issues/2809) for more info on why we use this version "to support leading zeros"