### PR TITLE
Fixed incorrect 'packages' on 'create release' workflow step.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -209,13 +209,13 @@ jobs:
           # - Nuget.CommandLine = 6.14.0 (this not listed here will resolve to its PackageID)
           packages: |
             Package Push - NuGet.CommandLine:SourcePackage:${{ env.PACKAGE_VERSION }}
-            *:NuGet.Common:${{ env.PACKAGE_VERSION }}
-            *:NuGet.Configuration:${{ env.PACKAGE_VERSION }}
-            *:NuGet.Frameworks:${{ env.PACKAGE_VERSION }}
-            *:NuGet.Packaging:${{ env.PACKAGE_VERSION }}
-            *:NuGet.Protocol:${{ env.PACKAGE_VERSION }}
-            *:NuGet.Versioning:${{ env.PACKAGE_VERSION }}
-            *:NuGet.PackageManagement:${{ env.PACKAGE_VERSION }}
-            *:NuGet.Build.Tasks:${{ env.PACKAGE_VERSION }}
-            *:NuGet.Commands:${{ env.PACKAGE_VERSION }}
-            *:NuGet.Resolver:${{ env.PACKAGE_VERSION }}
+            NuGet.Common:${{ env.PACKAGE_VERSION }}
+            NuGet.Configuration:${{ env.PACKAGE_VERSION }}
+            NuGet.Frameworks:${{ env.PACKAGE_VERSION }}
+            NuGet.Packaging:${{ env.PACKAGE_VERSION }}
+            NuGet.Protocol:${{ env.PACKAGE_VERSION }}
+            NuGet.Versioning:${{ env.PACKAGE_VERSION }}
+            NuGet.PackageManagement:${{ env.PACKAGE_VERSION }}
+            NuGet.Build.Tasks:${{ env.PACKAGE_VERSION }}
+            NuGet.Commands:${{ env.PACKAGE_VERSION }}
+            NuGet.Resolver:${{ env.PACKAGE_VERSION }}


### PR DESCRIPTION
# Background 
The release was not selecting the specified `package+version` specified here and was using the "default" that is the 'latest' package added on the built-in feed.

<img width="1629" height="659" alt="image" src="https://github.com/user-attachments/assets/5f39225b-c450-40de-afb8-ccee4e645797" />

But the `NuGet.CommandLine` package was correct.

# Result
Reverted the packages version specification as the wildcard is not actually supported.