### PR TITLE
Add missing 'use original version' commit from the pack command

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
@@ -182,7 +182,7 @@ namespace NuGet.CommandLine
                 {
                     throw new PackagingException(NuGetLogCode.NU5010, string.Format(CultureInfo.CurrentCulture, NuGetResources.InstallCommandPackageReferenceInvalidVersion, Version));
                 }
-                packArgs.Version = version.ToFullString();
+                packArgs.Version = version.ToString();
             }
 
             var packCommandRunner = new PackCommandRunner(packArgs, ProjectFactory.ProjectCreator);


### PR DESCRIPTION
# Background

We found a 'missing' commit on the original fork related to https://github.com/OctopusDeploy/NuGet.Client/pull/13 this uses the passed version instead of the full string version for the "pack" command.

# Result

This PR will add the missing commit that updates the package command to use the default `ToString` instead of `ToFullString` to match original https://github.com/OctopusDeploy/NuGet.Client/commit/6f9a9a7a8a095d12a2bead30ac97286377a91354

This means that we will properly support https://github.com/OctopusDeploy/Issues/issues/2809, i suspect that the 