### PR TITLE
Update HttpSourceResourceProvider to create a new HttpClient when the credentials change

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -186,7 +186,8 @@ namespace NuGet.Configuration
             }
 
             return Name.Equals(other.Name, StringComparison.CurrentCultureIgnoreCase) &&
-                   Source.Equals(other.Source, StringComparison.OrdinalIgnoreCase);
+                   Source.Equals(other.Source, StringComparison.OrdinalIgnoreCase) &&
+                   Equals(Credentials, other.Credentials);
         }
 
         public override bool Equals(object? obj)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -120,5 +120,33 @@ namespace NuGet.Configuration.Test
             source.IsLocal.Should().BeTrue();
             source.GetHashCode().Should().NotBe(hashCodeBefore);
         }
+
+        [Fact]
+        public void Equals_WithDifferentCredentials_AreNotEqual()
+        {
+            var a = CreateSourceForPasswordEquality("Foo");
+            var b = CreateSourceForPasswordEquality("Bar");
+
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void Equals_WithSameCredentials_AreEqual()
+        {
+            var a = CreateSourceForPasswordEquality("Foo");
+            var b = CreateSourceForPasswordEquality("Foo");
+
+            Assert.Equal(a, b);
+        }
+        private static PackageSource CreateSourceForPasswordEquality(string password)
+        {
+            var credentials = new PackageSourceCredential("SourceName", "username", password, isPasswordClearText: false, null);
+            var source = new PackageSource("Source", "SourceName", isEnabled: false)
+            {
+                Credentials = credentials,
+                ProtocolVersion = 43
+            };
+            return source;
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
@@ -62,5 +62,50 @@ namespace NuGet.Protocol.Tests
             Assert.NotNull(httpSourceResource);
             Assert.Equal(maxHttpRequestsPerSource, sourceRepository.PackageSource.MaxHttpRequestsPerSource);
         }
+
+        [Fact]
+        public async Task WhenSourceRepositoryHasDifferentCredentialsPassword_ReturnsDifferentHttpSourceResources()
+        {
+            // Arrange
+            var sourceRepositoryA = CreateSourceRepositoryForPasswordEquality("Foo");
+            var sourceRepositoryB = CreateSourceRepositoryForPasswordEquality("Bar");
+
+            // Act
+            var provider = new HttpSourceResourceProvider();
+            var a = await provider.TryCreate(sourceRepositoryA, CancellationToken.None);
+            var b = await provider.TryCreate(sourceRepositoryB, CancellationToken.None);
+
+            // Assert
+            Assert.NotSame(a.Item2, b.Item2);
+        }
+
+        [Fact]
+        public async Task WhenSourceRepositoryHasTheSameCredentialsPassword_ReturnsTheSameHttpSourceResource()
+        {
+            // Arrange
+            var sourceRepositoryA = CreateSourceRepositoryForPasswordEquality("Foo");
+            var sourceRepositoryB = CreateSourceRepositoryForPasswordEquality("Foo");
+
+            // Act
+            var provider = new HttpSourceResourceProvider();
+            var a = await provider.TryCreate(sourceRepositoryA, CancellationToken.None);
+            var b = await provider.TryCreate(sourceRepositoryB, CancellationToken.None);
+
+            // Assert
+            Assert.Same(a.Item2, b.Item2);
+        }
+
+        private SourceRepository CreateSourceRepositoryForPasswordEquality(string password)
+        {
+            return new SourceRepository(
+                new PackageSource(_testPackageSourceURL)
+                {
+                    Credentials = new PackageSourceCredential(_testPackageSourceURL, "user", password, true, null)
+                },
+                [
+                    new HttpSourceResourceProvider()
+                ]
+            );
+        }
     }
 }


### PR DESCRIPTION
# Background

To support existing functionality and in regards to the HTTP Client Caching within Octopus Deploy we need to re-implement the following commits:

https://github.com/OctopusDeploy/NuGet.Client/commit/dd0d988edb3afac27ae958b094d451dc535766b7#diff-2e2f5bc7aba32eb58bd35315bbc3322399bbf8efd6e84fe7ef1bd95b45dab6a3

We have implemented a new integration test file within octopus deploy called `WhenUsingNugetFeedCredentials` that covers this case to verify that the current release without the changes from above commit  applied.

The original rationale was in this issue: https://github.com/OctopusDeploy/Issues/issues/2959 and the proposed [fix at the time was ignored](https://github.com/NuGet/NuGet.Client/pull/1153) so a decision was made to "override" the proxy instead to insulate us from the ProxyCache.

# Result

As 6.14 has diverged, another individual has implemented some of the [equality changes](https://github.com/NuGet/NuGet.Client/commit/fc0c2072b79674975d6fac5f332ae8359cef094a), so we didn't need to make all the same changes, but we did add some further unit tests.

This pr has added credentials to the equality comparer for PackageSource so that when HttpSourceResourceProvider caches HttpClients, it creates a new client when the credentials change. 

Previously it was returning the same HttpClient (which already has credentials set) regardles of the PackageSource.Credentails value.

# Before

Version: 6.14.1-release.3601
<img width="1043" height="500" alt="image" src="https://github.com/user-attachments/assets/792e2900-059f-4259-8e20-3fac62d1c19b" />

# After
Version: 6.14.1-xprivate.3801 [(this PR branch build)](https://github.com/OctopusDeploy/NuGet.Client/actions/runs/18892326243)
<img width="1254" height="49" alt="image" src="https://github.com/user-attachments/assets/3b0b7e23-fd67-4a4d-bd46-45f96a3c4568" />
