### PR TITLE
Update nuget package versioning to use "octopus" and "branch name"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,11 +71,11 @@ jobs:
             # All merges to "release/*" branches are considered release builds.
             $releaseLabel = "octopus-release"
           } else {
-            # Use the branch name, sanitizing it for version strings
-            $releaseLabel = $branchName -replace '[^a-zA-Z0-9\-\.]', '-'
+            # Use the branch name, sanitizing it for version strings and prefix with pr-
+            $releaseLabel = "pr-" + ($branchName -replace '[^a-zA-Z0-9\-\.]', '-')
 
             # Final Version must be less than 64 chars to comply with nuget version string limit
-            # e.g. feature-very-long-branch-name-that-exceeds-forty-characters -> "6.14.1-feature-very-long-branch-name-that-exce".1111"
+            # e.g. pr-feature-very-long-branch-name-that-exceeds -> "6.14.1-pr-feature-very-long-branch-name-that-exc.1111"
             if ($releaseLabel.Length -gt 40) {
               $releaseLabel = $releaseLabel.Substring(0, 40)
             }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on:
   push:
     # Triggers the workflow on pull request events and merges/pushes to master
     branches:
-      - octopus
       - release/*
     tags-ignore:
       - '**'
@@ -65,13 +64,13 @@ jobs:
       - name: Set Release Label
         run: |
           if ("${{ github.event_name }}" -eq "schedule") {
-            $releaseLabel = "nightly$(Get-Date -Format 'yyyyMMdd')"
-          } elseif ("${{ github.ref_name }}" -eq "${{ github.event.repository.default_branch }}") {
-            $releaseLabel = "final"
+            $releaseLabel = "octopus-nightly-$(Get-Date -Format 'yyyyMMdd')"
           } elseif ("${{ github.ref_name }}" -like "release/*") {
-            $releaseLabel = "release"
+            # All merges to "release/*" branches are considered release builds.
+            $releaseLabel = "octopus-release"
           } else {
-            $releaseLabel = "xprivate"
+            # Use the branch name, sanitizing it for version strings
+            $releaseLabel = "${{ github.ref_name }}" -replace '[^a-zA-Z0-9\-\.]', '-'
           }
           Write-Host "event_name: ${{ github.event_name }}"
           Write-Host "ref_name: ${{ github.ref_name }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,20 +63,21 @@ jobs:
 
       - name: Set Release Label
         run: |
+          $branchName = "${{ github.head_ref || github.ref_name }}"
+
           if ("${{ github.event_name }}" -eq "schedule") {
             $releaseLabel = "octopus-nightly-$(Get-Date -Format 'yyyyMMdd')"
-          } elseif ("${{ github.ref_name }}" -like "release/*") {
+          } elseif ($branchName -like "release/*") {
             # All merges to "release/*" branches are considered release builds.
             $releaseLabel = "octopus-release"
           } else {
             # Use the branch name, sanitizing it for version strings
-            $releaseLabel = "${{ github.ref_name }}" -replace '[^a-zA-Z0-9\-\.]', '-'
+            $releaseLabel = $branchName -replace '[^a-zA-Z0-9\-\.]', '-'
           }
           Write-Host "event_name: ${{ github.event_name }}"
-          Write-Host "ref_name: ${{ github.ref_name }}"
-          Write-Host "default_branch: ${{ github.event.repository.default_branch }}"
+          Write-Host "branch_name: $branchName"
+          Write-Host "release_label: $releaseLabel"
 
-          Write-Host "Release label: $releaseLabel"
           echo "RELEASE_LABEL=$releaseLabel" >> $env:GITHUB_ENV
         shell: powershell
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,12 @@ jobs:
           } else {
             # Use the branch name, sanitizing it for version strings
             $releaseLabel = $branchName -replace '[^a-zA-Z0-9\-\.]', '-'
+
+            # Final Version must be less than 64 chars to comply with nuget version string limit
+            # e.g. feature-very-long-branch-name-that-exceeds-forty-characters -> "6.14.1-feature-very-long-branch-name-that-exce".1111"
+            if ($releaseLabel.Length -gt 40) {
+              $releaseLabel = $releaseLabel.Substring(0, 40)
+            }
           }
           Write-Host "event_name: ${{ github.event_name }}"
           Write-Host "branch_name: $branchName"

--- a/build.ps1
+++ b/build.ps1
@@ -40,7 +40,7 @@ param (
     [ValidateSet('debug', 'release')]
     [Alias('c')]
     [string]$Configuration,
-    [ValidatePattern('^(beta|final|preview|rc|release|rtm|xprivate|zlocal|nightly)([0-9]*)$')]
+    [ValidatePattern('^[a-zA-Z0-9\-\.]+$')]
     [Alias('l')]
     [string]$ReleaseLabel = 'zlocal',
     [Alias('n')]

--- a/build/config.props
+++ b/build/config.props
@@ -54,20 +54,13 @@
     <!-- If we aren't excluding the build number, use the release label and the build number. -->
     <When Condition="'$(BuildRTM)' != 'true' AND '$(PreReleaseVersion)' != '' AND '$(PreReleaseVersion)' != '0' ">
       <PropertyGroup>
-        <PreReleaseInformationVersion Condition="'$(ReleaseLabel)' == 'final'">-octopus.$(PreReleaseVersion)</PreReleaseInformationVersion>
-        <PreReleaseInformationVersion Condition="'$(ReleaseLabel)' != 'final'">-$(ReleaseLabel).$(PreReleaseVersion)</PreReleaseInformationVersion>
+        <PreReleaseInformationVersion>-$(ReleaseLabel).$(PreReleaseVersion)</PreReleaseInformationVersion>
       </PropertyGroup>
     </When>
     <!-- If we are excluding the build number, show the release label unless we are RTM. -->
-    <When Condition="'$(ReleaseLabel)' != 'rtm' AND '$(ReleaseLabel)' != 'svc' AND '$(ReleaseLabel)' != 'rc' AND '$(ReleaseLabel)' != 'final'">
+    <When Condition="'$(ReleaseLabel)' != 'rtm' AND '$(ReleaseLabel)' != 'svc' AND '$(ReleaseLabel)' != 'rc'">
       <PropertyGroup>
         <PreReleaseInformationVersion>-$(ReleaseLabel)</PreReleaseInformationVersion>
-      </PropertyGroup>
-    </When>
-    <!-- Special case for final without build number -->
-    <When Condition="'$(ReleaseLabel)' == 'final' AND ('$(PreReleaseVersion)' == '' OR '$(PreReleaseVersion)' == '0')">
-      <PropertyGroup>
-        <PreReleaseInformationVersion>-octopus</PreReleaseInformationVersion>
       </PropertyGroup>
     </When>
   </Choose>

--- a/runTests.ps1
+++ b/runTests.ps1
@@ -37,7 +37,7 @@ param (
     [ValidateSet('debug', 'release')]
     [Alias('c')]
     [string]$Configuration,
-    [ValidatePattern('^(beta|final|preview|rc|release|rtm|xprivate|zlocal|nightly)([0-9]*)$')]
+    [ValidatePattern('^[a-zA-Z0-9\-\.]+$')]
     [Alias('l')]
     [string]$ReleaseLabel = 'zlocal',
     [Alias('n')]


### PR DESCRIPTION
# Background

We want to include "octopus" in the version name to make it clear that the version is a "octopus" version, we also don't want to use xprivate as it doesn't provide information as to what is contained in the release, in the case two people have a branch, they would need to lookup the run number to identify the correct package

We decided not to use the current 'octopus' branch as a 'main' branch as it is not aligned with the official branching strategy and it could lead to confusion when we need to re-fork, or take changes from a new major version, so we decided just to continue with the `release/*` branches for now.

# Result

Updated Github Action to remove 'octopus' handling and append 'octopus' to the release labels, and reverted our changes to the build props that handled the 'octopus' case.

We also removed validation to the release label to allow for branch names 

Example:
<img width="912" height="498" alt="Screenshot 2025-11-04 105434" src="https://github.com/user-attachments/assets/8a1944d1-b63c-48b2-a19b-ea1809fda1bc" />
