### PR TITLE
Updated pr version prefix to be "dev" instead of "pr"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,11 +71,15 @@ jobs:
             # All merges to "release/*" branches are considered release builds.
             $releaseLabel = "octopus-release"
           } else {
-            # Use the branch name, sanitizing it for version strings and prefix with pr-
-            $releaseLabel = "pr-" + ($branchName -replace '[^a-zA-Z0-9\-\.]', '-')
+            # Since we use pre release, we need to prefix all branch names with dev- so it is
+            # alphabetically sorted to be lower than the above "octopus-release" if we don't.
+            # a branch name starting with a letter greater than "o" would be selected by renovate bot.\
+
+            # Use the branch name, sanitizing it for version strings and prefix with dev-
+            $releaseLabel = "dev-" + ($branchName -replace '[^a-zA-Z0-9\-\.]', '-')
 
             # Final Version must be less than 64 chars to comply with nuget version string limit
-            # e.g. pr-feature-very-long-branch-name-that-exceeds -> "6.14.1-pr-feature-very-long-branch-name-that-exc.1111"
+            # e.g. dev-feature-very-long-branch-name-that-exceeds -> "6.14.1-dev-feature-very-long-branch-name-that-exc.1111"
             if ($releaseLabel.Length -gt 40) {
               $releaseLabel = $releaseLabel.Substring(0, 40)
             }


### PR DESCRIPTION
# Background
NuGet feeds and feedz.io order alphabetically descending, this means that "renovate" thinks that packages created by pr's (dev packages) are "newer" and more recent than our "release" branch "octopus-release"

<img width="2243" height="239" alt="image" src="https://github.com/user-attachments/assets/845cf363-b31d-43b3-bc4a-f161b4604e5d" />

By using the prefix of "dev" instead of "pr" it will ensure that the packages created from pr's should come after the "Release packages".

# Result

<img width="1162" height="264" alt="image" src="https://github.com/user-attachments/assets/95672103-e086-4ab0-8622-0c69a2be20be" />
