### PR TITLE
Re-implement ReleaseNotes property support for V3 Feeds

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/PackageSearchMetadataContextInfo.cs
@@ -32,7 +32,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
         public Uri? PackageDetailsUrl { get; internal set; }
         public bool RequireLicenseAcceptance { get; internal set; }
         public string? Summary { get; internal set; }
-        public string? ReleaseNotes { get; internal set; }
         public bool PrefixReserved { get; internal set; }
         public bool IsRecommended { get; internal set; }
         public (string modelVersion, string vsixVersion)? RecommenderVersion { get; internal set; }
@@ -78,7 +77,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
                     (packageSearchMetadata as ClonedPackageSearchMetadata)?.PackagePath,
                 RequireLicenseAcceptance = packageSearchMetadata.RequireLicenseAcceptance,
                 Summary = packageSearchMetadata.Summary,
-                ReleaseNotes = packageSearchMetadata.ReleaseNotes,
                 PrefixReserved = packageSearchMetadata.PrefixReserved,
                 IsListed = packageSearchMetadata.IsListed,
                 DependencySets = packageSearchMetadata.DependencySets?.ToList(),

--- a/src/NuGet.Core/NuGet.Protocol/Converters/ParserConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/ParserConstants.cs
@@ -29,6 +29,7 @@ namespace NuGet.Protocol
         public const string Title = "title";
         public const string Summary = "summary";
         public const string Description = "description";
+        public const string ReleaseNotes = "releaseNotes";
         public const string Authors = "authors";
         public const string Owners = "owners";
         public const string IconUrl = "iconUrl";

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -80,7 +80,7 @@ namespace NuGet.Protocol
                 cacheResult.CacheFile,
                 action: async lockedToken =>
                 {
-                    cacheResult.Stream = TryReadCacheFile(request.Uri, cacheResult.MaxAge, cacheResult.CacheFile);
+                    cacheResult.Stream = null; //TryReadCacheFile(request.Uri, cacheResult.MaxAge, cacheResult.CacheFile);
                     try
                     {
                         if (cacheResult.Stream != null)

--- a/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
@@ -34,7 +34,6 @@ namespace NuGet.Protocol.Core.Types
         string Summary { get; }
         string Tags { get; }
         string Title { get; }
-        string ReleaseNotes { get; }
 
         bool IsListed { get; }
         bool PrefixReserved { get; }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -142,7 +142,7 @@ namespace NuGet.Protocol
             private set { _titleValue = value; }
         }
 
-        [JsonIgnore]
+        [JsonProperty(PropertyName = JsonProperties.ReleaseNotes)]
         public string ReleaseNotes { get; private set; }
 
         [JsonProperty(PropertyName = JsonProperties.Version)]

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1626,6 +1626,7 @@ const NuGet.Protocol.JsonExtensions.JsonSerializationMaxDepth = 512 -> int
 ~const NuGet.Protocol.JsonProperties.Range = "range" -> string
 ~const NuGet.Protocol.JsonProperties.ReadmeFileUrl = "readmeFileUrl" -> string
 ~const NuGet.Protocol.JsonProperties.ReadmeUrl = "readmeUrl" -> string
+~const NuGet.Protocol.JsonProperties.ReleaseNotes = "releaseNotes" -> string
 ~const NuGet.Protocol.JsonProperties.RequireLicenseAcceptance = "requireLicenseAcceptance" -> string
 ~const NuGet.Protocol.JsonProperties.Severity = "severity" -> string
 ~const NuGet.Protocol.JsonProperties.SigningCertificates = "signingCertificates" -> string

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1622,6 +1622,7 @@ const NuGet.Protocol.JsonExtensions.JsonSerializationMaxDepth = 512 -> int
 ~const NuGet.Protocol.JsonProperties.Range = "range" -> string
 ~const NuGet.Protocol.JsonProperties.ReadmeFileUrl = "readmeFileUrl" -> string
 ~const NuGet.Protocol.JsonProperties.ReadmeUrl = "readmeUrl" -> string
+~const NuGet.Protocol.JsonProperties.ReleaseNotes = "releaseNotes" -> string
 ~const NuGet.Protocol.JsonProperties.RequireLicenseAcceptance = "requireLicenseAcceptance" -> string
 ~const NuGet.Protocol.JsonProperties.Severity = "severity" -> string
 ~const NuGet.Protocol.JsonProperties.SigningCertificates = "signingCertificates" -> string

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1622,6 +1622,7 @@ const NuGet.Protocol.JsonExtensions.JsonSerializationMaxDepth = 512 -> int
 ~const NuGet.Protocol.JsonProperties.Range = "range" -> string
 ~const NuGet.Protocol.JsonProperties.ReadmeFileUrl = "readmeFileUrl" -> string
 ~const NuGet.Protocol.JsonProperties.ReadmeUrl = "readmeUrl" -> string
+~const NuGet.Protocol.JsonProperties.ReleaseNotes = "releaseNotes" -> string
 ~const NuGet.Protocol.JsonProperties.RequireLicenseAcceptance = "requireLicenseAcceptance" -> string
 ~const NuGet.Protocol.JsonProperties.Severity = "severity" -> string
 ~const NuGet.Protocol.JsonProperties.SigningCertificates = "signingCertificates" -> string

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -62,7 +63,18 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            return await GetMetadataAsync(packageId, includePrerelease, includeUnlisted, range: VersionRange.All, sourceCacheContext, log, token);
+
+            var metadataList = await _regResource.GetPackageMetadata(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+            return metadataList.Select(ParseMetadata);
+            // This is the "new" get metadata.
+            // return await GetMetadataAsync(packageId, includePrerelease, includeUnlisted, range: VersionRange.All, sourceCacheContext, log, token);
+        }
+
+        private IPackageSearchMetadata ParseMetadata(JObject metadata)
+        {
+            var parsed = metadata.FromJToken<PackageSearchMetadata>();
+            parsed.ReportAbuseUrl = _reportAbuseResource?.GetReportAbuseUrl(parsed.PackageId, parsed.Version);
+            return parsed;
         }
 
         /// <summary>
@@ -98,6 +110,7 @@ namespace NuGet.Protocol
             var metadataCache = new MetadataReferenceCache();
             var registrationUri = _regResource.GetUri(packageId);
 
+            // This is "optimised" and doesnt include release notes.
             var (registrationIndex, httpSourceCacheContext) = await LoadRegistrationIndexAsync(
                 _client,
                 registrationUri,
@@ -216,7 +229,7 @@ namespace NuGet.Protocol
         }
 
         /// <summary>
-        /// Process RegistrationIndex 
+        /// Process RegistrationIndex
         /// </summary>
         /// <param name="httpSource">Httpsource instance.</param>
         /// <param name="rangeUri">Paged registration index url address.</param>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/JsonExtensionsTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/JsonExtensionsTest.cs
@@ -38,5 +38,18 @@ namespace NuGet.Protocol.Tests
             Assert.Equal("this is a message", metaData.DeprecationMetadata.Message);
             Assert.Null(metaData.DeprecationMetadata.AlternatePackage);
         }
+
+        [Fact]
+        public void FromJTokenWithReleaseNotes()
+        {
+            // Arrange
+            var token = JToken.Parse(JsonData.PackageRegistrationCatalogEntryWithReleaseNotes);
+
+            // Act
+            var metaData = token.FromJToken<PackageSearchMetadata>();
+
+            // Assert
+            Assert.Equal("v5.0 is a major release with significant new resilience", metaData.ReleaseNotes);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -48,7 +49,7 @@ namespace NuGet.Protocol.Tests
                 Assert.Null(result.IconUrl);
                 Assert.Null(result.LicenseUrl);
                 Assert.Equal("http://github.com/jamesfoster/DeepEqual", result.ProjectUrl.ToString());
-                Assert.Equal("https://api.nuget.org/v3/catalog0/data/2015.02.03.18.34.51/deepequal.0.9.0.json",
+                Assert.Equal("https://api.nuget.org/v3/catalog0/data/2018.10.15.10.13.37/polly.5.0.5.json",
                     result.CatalogUri.ToString());
                 Assert.Equal(DateTimeOffset.Parse("2013-08-28T09:19:10.013Z"), result.Published);
                 Assert.False(result.RequireLicenseAcceptance);
@@ -56,6 +57,45 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(string.Join(", ", "deepequal", "deep", "equal"), result.Tags);
                 Assert.Equal("DeepEqual", result.Title);
                 Assert.True(result.IsListed);
+                Assert.Equal("Release notes for version 0.9.0", result.ReleaseNotes);
+            }
+        }
+
+        [Fact]
+        public async Task PackageMetadataResourceV3_GetMetadataAsync2()
+        {
+            // Arrange
+            // var responses = new Dictionary<string, string>();
+            // responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
+            // responses.Add("https://api.nuget.org/v3/registration0/deepequal/index.json", JsonData.DeepEqualRegistationIndex);
+
+            var repo = new SourceRepository(new PackageSource("https://api.nuget.org/v3/index.json"), Repository.Provider.GetCoreV3());
+
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+
+            var package = new PackageIdentity("polly", NuGetVersion.Parse("5.0.5"));
+
+            // Act
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                // string packageId,
+                // bool includePrerelease,
+                // bool includeUnlisted,
+                //     SourceCacheContext sourceCacheContext,
+                // Common.ILogger log,
+                //     CancellationToken token);
+                var packages = await resource.GetMetadataAsync(
+                    package.Id,
+                    true,
+                    false,
+                    sourceCacheContext,
+                    Common.NullLogger.Instance, CancellationToken.None);
+
+                var result = packages.FirstOrDefault(p => p.Identity.Version.ToString() == "5.0.5");
+                // Assert
+                Assert.Equal("polly", result.Identity.Id, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal("5.0.5", result.Identity.Version.ToNormalizedString());
+                Assert.Equal("Release notes for version 0.9.0", result.ReleaseNotes);
             }
         }
 

--- a/test/TestUtilities/Test.Utility/JsonData.cs
+++ b/test/TestUtilities/Test.Utility/JsonData.cs
@@ -21,7 +21,7 @@ namespace Test.Utility
   {
    ""@id"": ""https://api-search.nuget.org/"",
    ""@type"": ""SearchGalleryQueryService""
-  },  
+  },
   {
    ""@id"": ""https://api-metrics.nuget.org/DownloadEvent"",
    ""@type"": ""MetricsService""
@@ -49,7 +49,7 @@ namespace Test.Utility
   {
    ""@id"": ""https://api-search.nuget.org/"",
    ""@type"": ""SearchGalleryQueryService/3.0.0-rc""
-  },  
+  },
   {
    ""@id"": ""https://api-metrics.nuget.org/DownloadEvent"",
    ""@type"": ""MetricsService/3.0.0-rc""
@@ -81,7 +81,7 @@ namespace Test.Utility
   {
    ""@id"": ""https://api-search.nuget.org/"",
    ""@type"": ""SearchGalleryQueryService/3.0.0-beta""
-  },  
+  },
   {
    ""@id"": ""https://api-metrics.nuget.org/DownloadEvent"",
    ""@type"": ""MetricsService/3.0.0-beta""
@@ -122,7 +122,7 @@ namespace Test.Utility
   {
    ""@id"": ""https://api-search.nuget.org/"",
    ""@type"": ""SearchGalleryQueryService""
-  },  
+  },
   {
    ""@id"": ""https://api-metrics.nuget.org/DownloadEvent"",
    ""@type"": ""MetricsService""
@@ -155,7 +155,7 @@ namespace Test.Utility
   {
    ""@id"": ""https://api-search.nuget.org/"",
    ""@type"": ""SearchGalleryQueryService/3.0.0-rc""
-  },  
+  },
   {
    ""@id"": ""https://api-metrics.nuget.org/DownloadEvent"",
    ""@type"": ""MetricsService/3.0.0-rc""
@@ -187,7 +187,7 @@ namespace Test.Utility
   {
    ""@id"": ""https://api-search.nuget.org/"",
    ""@type"": ""SearchGalleryQueryService/3.0.0-beta""
-  },  
+  },
   {
    ""@id"": ""https://api-metrics.nuget.org/DownloadEvent"",
    ""@type"": ""MetricsService/3.0.0-beta""
@@ -4831,6 +4831,83 @@ namespace Test.Utility
     ],
     ""title"": """",
     ""version"": ""0.0.0""
+}";
+        #endregion
+
+        #region PackageRegistrationCatalogEntryWithReleaseNotes
+        public const string PackageRegistrationCatalogEntryWithReleaseNotes = @"{
+  ""@id"": ""https://api.nuget.org/v3/catalog0/data/2018.10.15.10.13.37/polly.5.0.5.json"",
+  ""@type"": [
+    ""PackageDetails"",
+    ""catalog:Permalink""
+  ],
+  ""authors"": ""Michael Wolfenden, App vNext"",
+  ""catalog:commitId"": ""970789a8-0a65-4220-ab09-eb595e521b4c"",
+  ""catalog:commitTimeStamp"": ""2018-10-15T10:13:37.2173685Z"",
+  ""copyright"": ""Copyright © 2016, App vNext"",
+  ""created"": ""2017-02-04T22:22:58.457Z"",
+  ""description"": ""Polly is a .NET 4.0 / 4.5 / .NET Standard 1.0 library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation and Fallback in a fluent and thread-safe manner."",
+  ""iconUrl"": ""https://raw.github.com/App-vNext/Polly/master/Polly.png"",
+  ""id"": ""Polly"",
+  ""isPrerelease"": false,
+  ""language"": ""en-US"",
+  ""lastEdited"": ""2018-10-15T10:13:29.13Z"",
+  ""licenseUrl"": ""https://raw.github.com/App-vNext/Polly/master/LICENSE.txt"",
+  ""listed"": true,
+  ""packageHash"": ""nhM5HbS9iPWiHnViv722ehKAnEYUGhAvhYIxI67BEoaCaplXh9qsMNKG4X7Licyv/plw6vAieM/mhWLujGdTug=="",
+  ""packageHashAlgorithm"": ""SHA512"",
+  ""packageSize"": 435694,
+  ""projectUrl"": ""https://github.com/App-vNext/Polly"",
+  ""published"": ""2017-02-04T22:22:58.457Z"",
+  ""releaseNotes"": ""v5.0 is a major release with significant new resilience"",
+  ""requireLicenseAcceptance"": false,
+  ""title"": ""Polly"",
+  ""verbatimVersion"": ""5.0.5"",
+  ""version"": ""5.0.5"",
+  ""dependencyGroups"": [
+  ],
+  ""packageEntries"": [
+
+  ],
+  ""tags"": [
+  ],
+  ""@context"": {
+    ""@vocab"": ""http://schema.nuget.org/schema#"",
+    ""catalog"": ""http://schema.nuget.org/catalog#"",
+    ""xsd"": ""http://www.w3.org/2001/XMLSchema#"",
+    ""dependencies"": {
+      ""@id"": ""dependency"",
+      ""@container"": ""@set""
+    },
+    ""dependencyGroups"": {
+      ""@id"": ""dependencyGroup"",
+      ""@container"": ""@set""
+    },
+    ""packageEntries"": {
+      ""@id"": ""packageEntry"",
+      ""@container"": ""@set""
+    },
+    ""supportedFrameworks"": {
+      ""@id"": ""supportedFramework"",
+      ""@container"": ""@set""
+    },
+    ""tags"": {
+      ""@id"": ""tag"",
+      ""@container"": ""@set""
+    },
+    ""published"": {
+      ""@type"": ""xsd:dateTime""
+    },
+    ""created"": {
+      ""@type"": ""xsd:dateTime""
+    },
+    ""lastEdited"": {
+      ""@type"": ""xsd:dateTime""
+    },
+    ""catalog:commitTimeStamp"": {
+      ""@type"": ""xsd:dateTime""
+    }
+  }
 }";
         #endregion
 


### PR DESCRIPTION
# Background

There was a bug introduced by the re-fork of https://github.com/OctopusDeploy/NuGet.Client/pull/10 where instead of returning `ReleaseNotes` for both v3 and v2 endpoints, it only returned release notes for v2 endpoints. 

In the image below you can see the release notes only show up for the v2 endpoint.

<img width="878" height="397" alt="image" src="https://github.com/user-attachments/assets/0d14c1d5-d0b6-4f57-b635-4ddd45499cb4" />

The release notes exist on the 'catalog'  and need to be mapped correctly

See the following: `https://api.nuget.org/v3/registration5-gz-semver2/polly/index.json` 
<img width="2037" height="1998" alt="image" src="https://github.com/user-attachments/assets/000c0014-adfb-4d65-89b9-46220d2cd78c" />

the catalog url links to the catalog data that has the release notes
```
https://api.nuget.org/v3/catalog0/data/2023.06.15.13.13.08/polly.8.0.0-alpha.1.json
```
<img width="1396" height="952" alt="image" src="https://github.com/user-attachments/assets/fbfdcecc-9bcb-4ad2-9bd5-a225ebbc0652" />


# Results

Updated PackageSearchMetadata.cs to include Release Notes, the mapping was being ignored for v3 endpoints.
