### PR TITLE
Release/7.3.x octopus fork

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,231 @@
+name: Build, Test, Package and Push
+
+# Controls when the action will run.
+on:
+  push:
+    # Triggers the workflow on pull request events and merges/pushes to master
+    branches:
+      - release/*
+    tags-ignore:
+      - '**'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+  schedule:
+    # Daily 5am australian/brisbane time
+    - cron: '0 19 * * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  # Required for deploying to octopus.
+  OCTOPUS_SPACE: "Core Platform"
+
+jobs:
+  build-packages:
+    runs-on: windows-latest
+    permissions:
+      id-token: write # Required to obtain the ID token from GitHub Actions
+      contents: write # Read Required to check out code, Write to create Git Tags
+      checks: write # Required for test-reporter
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Set Octopus Deploy Flag
+        run: |
+          $shouldDeploy = $true
+
+          # Skip if dependabot or prettybot
+          if ("${{ github.ref }}" -like "*dependabot*" -or "${{ github.ref }}" -like "*prettybot*") {
+            $shouldDeploy = $false
+          }
+
+          # Skip merge builds unless targeting octopus or release branches
+          if ("${{ github.ref }}" -like "*/merge" -and
+              "${{ github.base_ref }}" -notlike "*octopus*" -and
+              "${{ github.base_ref }}" -notlike "*release/*") {
+            $shouldDeploy = $false
+          }
+          Write-Host "ref: ${{ github.ref }}"
+          Write-Host "base_ref: ${{ github.base_ref }}"
+          Write-Host "shouldDeploy: $shouldDeploy"
+
+          echo "DEPLOY_TO_OCTOPUS=$shouldDeploy" >> $env:GITHUB_ENV
+        shell: powershell
+
+      - name: Set Release Label
+        run: |
+          $branchName = "${{ github.head_ref || github.ref_name }}"
+
+          if ("${{ github.event_name }}" -eq "schedule") {
+            $releaseLabel = "octopus-nightly-$(Get-Date -Format 'yyyyMMdd')"
+          } elseif ($branchName -like "release/*") {
+            # All merges to "release/*" branches are considered release builds.
+            $releaseLabel = "octopus-release"
+          } else {
+            # Since we use pre release, we need to prefix all branch names with dev- so it is
+            # alphabetically sorted to be lower than the above "octopus-release" if we don't.
+            # a branch name starting with a letter greater than "o" would be selected by renovate bot.\
+
+            # Use the branch name, sanitizing it for version strings and prefix with dev-
+            $releaseLabel = "dev-" + ($branchName -replace '[^a-zA-Z0-9\-\.]', '-')
+
+            # Final Version must be less than 64 chars to comply with nuget version string limit
+            # e.g. dev-feature-very-long-branch-name-that-exceeds -> "6.14.1-dev-feature-very-long-branch-name-that-exc.1111"
+            if ($releaseLabel.Length -gt 40) {
+              $releaseLabel = $releaseLabel.Substring(0, 40)
+            }
+          }
+          Write-Host "event_name: ${{ github.event_name }}"
+          Write-Host "branch_name: $branchName"
+          Write-Host "release_label: $releaseLabel"
+
+          echo "RELEASE_LABEL=$releaseLabel" >> $env:GITHUB_ENV
+        shell: powershell
+
+      - name: Set BuildNumber
+        run: |
+          $runAttempt = "${{ github.run_attempt }}".PadLeft(2, '0')
+          $buildNumber = "${{ github.run_number }}$runAttempt"
+          Write-Host "buildNumber: $buildNumber"
+          echo "BUILD_NUMBER=$buildNumber" >> $env:GITHUB_ENV
+
+      - name: Set PackageVersion
+        run: |
+          $buildNumber = "${{ env.BUILD_NUMBER }}"
+          $releaseLabel = "${{ env.RELEASE_LABEL }}"
+
+          # Read version from config.props
+          $configPath = "build\config.props"
+          $configContent = Get-Content $configPath -Raw
+
+          $majorMatch = [regex]::Match($configContent, '<MajorNuGetVersion[^>]*>(\d+)</MajorNuGetVersion>')
+          $minorMatch = [regex]::Match($configContent, '<MinorNuGetVersion[^>]*>(\d+)</MinorNuGetVersion>')
+          $patchMatch = [regex]::Match($configContent, '<PatchNuGetVersion[^>]*>(\d+)</PatchNuGetVersion>')
+
+          $major = $majorMatch.Groups[1].Value
+          $minor = $minorMatch.Groups[1].Value
+          $patch = $patchMatch.Groups[1].Value
+          $baseVersion = "$major.$minor.$patch"
+          # This matches logic within the build that will take a 'final' and prepend 'octopus'
+          if ($releaseLabel -eq "final") {
+            $packageVersion = "$baseVersion-octopus.$buildNumber"
+          } else {
+            # E.g releaseLabel = (xprivate, release, nightly#####)
+            $packageVersion = "$baseVersion-$releaseLabel.$buildNumber"
+          }
+          Write-Host "packageVersion: $packageVersion"
+          # This needs to match the packages in the /artifacts/nupkgs/ folder after build
+          echo "PACKAGE_VERSION=$packageVersion" >> $env:GITHUB_ENV
+
+      # required for building the code see: https://github.com/NuGet/NuGet.Client/blob/dev/CONTRIBUTING.md#build
+      - name: Configure Build Environment
+        run: .\configure.ps1 -Force
+        shell: powershell
+
+      - name: Build NuGet Packages 📦
+        id: build
+        run: .\build.ps1 -Configuration Release -ReleaseLabel ${{ env.RELEASE_LABEL }} -BuildNumber ${{ env.BUILD_NUMBER }} -Fast -SkipUnitTest -CI
+
+      - name: Run NuGet.Core Unit Tests 🧪
+        run: |
+          Get-ChildItem -Path "test/NuGet.Core.Tests" -Filter "*.csproj" -Recurse | ForEach-Object {
+            dotnet test $_.FullName --configuration Release --no-build --logger trx --results-directory ./build/TestResults/ --verbosity minimal
+          }
+        shell: powershell
+
+      - name: Unit test report
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: NuGet Core unit test results
+          path: ./build/TestResults/*.trx
+          reporter: dotnet-trx
+          fail-on-error: true
+
+      - name: Tag release (when release label is final) 🏷️
+        if: ${{ env.RELEASE_LABEL == 'final' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ env.PACKAGE_VERSION }}",
+              sha: context.sha
+            })
+
+      - name: Login to Octopus Deploy 🐙
+        if: env.DEPLOY_TO_OCTOPUS == 'True'
+        uses: OctopusDeploy/login@v1
+        with:
+          server: ${{ secrets.OCTOPUS_URL }}
+          service_account_id: cc09980f-9a73-46c3-8f3f-e3f673740c1f
+
+      - name: Push build information to Octopus Deploy 🐙
+        uses: OctopusDeploy/push-build-information-action@v3
+        if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
+        with:
+          packages: |
+            NuGet.CommandLine
+            NuGet.Common
+            NuGet.Configuration
+            NuGet.Frameworks
+            NuGet.Packaging
+            NuGet.Protocol
+            NuGet.Versioning
+            NuGet.PackageManagement
+            NuGet.Build.Tasks
+            NuGet.Commands
+            NuGet.Resolver
+          version: ${{ env.PACKAGE_VERSION }}
+
+      - name: Push to Octopus 🐙
+        if: env.DEPLOY_TO_OCTOPUS == 'True'
+        uses: OctopusDeploy/push-package-action@v3
+        with:
+          packages: |
+            ./artifacts/nupkgs/NuGet.CommandLine.${{ env.PACKAGE_VERSION }}.nupkg
+            ./artifacts/nupkgs/NuGet.Common.${{ env.PACKAGE_VERSION }}.nupkg
+            ./artifacts/nupkgs/NuGet.Configuration.${{ env.PACKAGE_VERSION }}.nupkg
+            ./artifacts/nupkgs/NuGet.Frameworks.${{ env.PACKAGE_VERSION }}.nupkg
+            ./artifacts/nupkgs/NuGet.Packaging.${{ env.PACKAGE_VERSION }}.nupkg
+            ./artifacts/nupkgs/NuGet.Protocol.${{ env.PACKAGE_VERSION }}.nupkg
+            ./artifacts/nupkgs/NuGet.Versioning.${{ env.PACKAGE_VERSION }}.nupkg
+            ./artifacts/nupkgs/NuGet.PackageManagement.${{ env.PACKAGE_VERSION }}.nupkg
+            ./artifacts/nupkgs/NuGet.Build.Tasks.${{ env.PACKAGE_VERSION }}.nupkg
+            ./artifacts/nupkgs/NuGet.Commands.${{ env.PACKAGE_VERSION }}.nupkg
+            ./artifacts/nupkgs/NuGet.Resolver.${{ env.PACKAGE_VERSION }}.nupkg
+
+      - name: Create Release in Octopus 🐙
+        if: env.DEPLOY_TO_OCTOPUS == 'True'
+        uses: OctopusDeploy/create-release-action@v3
+        with:
+          project: Nuget.Client
+          release_number: ${{ env.PACKAGE_VERSION }}
+          # Packages docs:
+          # Format: StepName:Version or PackageID:Version or StepName:PackageName:Version.
+          # We specifically target the package name of NuGet.CommandLine/SourcePackage because our step uses both
+          # - SourcePackage = ${{ env.PACKAGE_VERSION }} === 6.14.0-release.213 (this is StepName:PackageName:Version)
+          # - Nuget.CommandLine = 6.14.0 (this not listed here will resolve to its PackageID)
+          packages: |
+            Package Push - NuGet.CommandLine:SourcePackage:${{ env.PACKAGE_VERSION }}
+            NuGet.Common:${{ env.PACKAGE_VERSION }}
+            NuGet.Configuration:${{ env.PACKAGE_VERSION }}
+            NuGet.Frameworks:${{ env.PACKAGE_VERSION }}
+            NuGet.Packaging:${{ env.PACKAGE_VERSION }}
+            NuGet.Protocol:${{ env.PACKAGE_VERSION }}
+            NuGet.Versioning:${{ env.PACKAGE_VERSION }}
+            NuGet.PackageManagement:${{ env.PACKAGE_VERSION }}
+            NuGet.Build.Tasks:${{ env.PACKAGE_VERSION }}
+            NuGet.Commands:${{ env.PACKAGE_VERSION }}
+            NuGet.Resolver:${{ env.PACKAGE_VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
             $releaseLabel = "dev-" + ($branchName -replace '[^a-zA-Z0-9\-\.]', '-')
 
             # Final Version must be less than 64 chars to comply with nuget version string limit
-            # e.g. dev-feature-very-long-branch-name-that-exceeds -> "6.14.1-dev-feature-very-long-branch-name-that-exc.1111"
+            # e.g. dev-feature-very-long-branch-name-that-exceeds -> "7.3.0-dev-feature-very-long-branch-name-that-exc.1111"
             if ($releaseLabel.Length -gt 40) {
               $releaseLabel = $releaseLabel.Substring(0, 40)
             }
@@ -133,7 +133,7 @@ jobs:
 
       - name: Build NuGet Packages 📦
         id: build
-        run: .\build.ps1 -Configuration Release -ReleaseLabel ${{ env.RELEASE_LABEL }} -BuildNumber ${{ env.BUILD_NUMBER }} -Fast -SkipUnitTest -CI
+        run: .\build.ps1 -Configuration Release -ReleaseLabel ${{ env.RELEASE_LABEL }} -BuildNumber ${{ env.BUILD_NUMBER }} -Pack -CI
 
       - name: Run NuGet.Core Unit Tests 🧪
         run: |
@@ -215,7 +215,7 @@ jobs:
           # Packages docs:
           # Format: StepName:Version or PackageID:Version or StepName:PackageName:Version.
           # We specifically target the package name of NuGet.CommandLine/SourcePackage because our step uses both
-          # - SourcePackage = ${{ env.PACKAGE_VERSION }} === 6.14.0-release.213 (this is StepName:PackageName:Version)
+          # - SourcePackage = ${{ env.PACKAGE_VERSION }} === 7.3.0-release.213 (this is StepName:PackageName:Version)
           # - Nuget.CommandLine = 6.14.0 (this not listed here will resolve to its PackageID)
           packages: |
             Package Push - NuGet.CommandLine:SourcePackage:${{ env.PACKAGE_VERSION }}

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ launchSettings.json
 
 # Image manifests are generated at build-time for VSIX
 *.imagemanifest
+.claude/settings.local.json

--- a/build.ps1
+++ b/build.ps1
@@ -35,7 +35,7 @@ To run full clean build, e.g after switching branches
 
 .EXAMPLE
 .\build.ps1 -f
-Fast incremental build
+Clean build (clears artifacts before building)
 
 .EXAMPLE
 .\build.ps1 -v -ea Stop
@@ -169,7 +169,7 @@ Invoke-BuildStep $VSMessage {
         $buildArgs += "-bl:msbuild.build.binlog"
     }
 
-    # Build and (If not $SkipUnitTest) Pack, Core unit tests, and Unit tests for VS
+    # Build and (If $RunUnitTests) Pack, Core unit tests, and Unit tests for VS
     Trace-Log ". `"$MSBuildExe`" $buildArgs"
     & $MSBuildExe @buildArgs
 
@@ -227,7 +227,7 @@ Invoke-BuildStep 'Running Restore RTM' {
 
 Invoke-BuildStep 'Packing RTM' {
 
-    # Build and (If not $SkipUnitTest) Pack, Core unit tests, and Unit tests for VS
+    # Build and Pack for RTM
     $packArgs = "build\build.proj", "/t:BuildVS`;Pack", "/p:Configuration=$Configuration", "/p:BuildRTM=true", "/p:ReleaseLabel=$ReleaseLabel", "/p:ExcludeTestProjects=true", "/v:m", "/m"
 
     if ($BuildNumber)

--- a/build.ps1
+++ b/build.ps1
@@ -46,7 +46,7 @@ param (
     [ValidateSet('debug', 'release')]
     [Alias('c')]
     [string]$Configuration,
-    [ValidatePattern('^(beta|final|preview|rc|release|rtm|xprivate|zlocal)([0-9]*)$')]
+    [ValidatePattern('^[a-zA-Z0-9\-\.]+$')]
     [Alias('l')]
     [string]$ReleaseLabel = 'zlocal',
     [Alias('n')]
@@ -221,7 +221,7 @@ Invoke-BuildStep 'Running Restore RTM' {
         exit 1
     }
 } `
--skip:(-not $CI)`
+-skip:(-not $CI -or ($ReleaseLabel -ne 'rtm'))`
 -ev +BuildErrors
 
 
@@ -249,7 +249,7 @@ Invoke-BuildStep 'Packing RTM' {
         exit 1
     }
 } `
--skip:(-not $CI)`
+-skip:(-not $CI -or ($ReleaseLabel -ne 'rtm'))`
 -ev +BuildErrors
 
 ## Calculating Build time

--- a/build/config.props
+++ b/build/config.props
@@ -60,7 +60,7 @@
       </PropertyGroup>
     </When>
     <!-- If we are excluding the build number, show the release label unless we are RTM. -->
-    <When Condition="'$(ReleaseLabel)' != 'rtm' AND '$(ReleaseLabel)' != 'svc' AND '$(ReleaseLabel)' != 'rc' ">
+    <When Condition="'$(ReleaseLabel)' != 'rtm' AND '$(ReleaseLabel)' != 'svc' AND '$(ReleaseLabel)' != 'rc'">
       <PropertyGroup>
         <PreReleaseInformationVersion>-$(ReleaseLabel)</PreReleaseInformationVersion>
       </PropertyGroup>
@@ -82,12 +82,12 @@
 
   <!-- Nuspec defaults -->
   <PropertyGroup>
-    <Authors>Microsoft</Authors>
-    <PackageProjectUrl>https://aka.ms/nugetprj</PackageProjectUrl>
+    <Authors>Microsoft, Octopus Deploy</Authors>
+    <PackageProjectUrl>https://github.com/OctopusDeploy/NuGet.Client</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/NuGet/NuGet.Client</RepositoryUrl>
+    <RepositoryUrl>https://github.com/OctopusDeploy/NuGet.Client</RepositoryUrl>
     <PackageTags>nuget</PackageTags>
     <Description>NuGet client library.</Description>
     <Copyright>&#169; Microsoft Corporation. All rights reserved.</Copyright>

--- a/runTests.ps1
+++ b/runTests.ps1
@@ -37,7 +37,7 @@ param (
     [ValidateSet('debug', 'release')]
     [Alias('c')]
     [string]$Configuration,
-    [ValidatePattern('^(beta|final|preview|rc|release|rtm|xprivate|zlocal)([0-9]*)$')]
+    [ValidatePattern('^[a-zA-Z0-9\-\.]+$')]
     [Alias('l')]
     [string]$ReleaseLabel = 'zlocal',
     [Alias('n')]

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -186,7 +186,8 @@ namespace NuGet.Configuration
             }
 
             return Name.Equals(other.Name, StringComparison.CurrentCultureIgnoreCase) &&
-                   Source.Equals(other.Source, StringComparison.OrdinalIgnoreCase);
+                   Source.Equals(other.Source, StringComparison.OrdinalIgnoreCase) &&
+                   Equals(Credentials, other.Credentials);
         }
 
         public override bool Equals(object? obj)

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -83,6 +83,7 @@ NuGet.Configuration.IPackageSourceProvider.LoadPackageSources() -> System.Collec
 NuGet.Configuration.IPackageSourceProvider.PackageSourcesChanged -> System.EventHandler?
 NuGet.Configuration.IPackageSourceProvider.RemovePackageSource(string! name) -> void
 NuGet.Configuration.IPackageSourceProvider.SaveActivePackageSource(NuGet.Configuration.PackageSource! source) -> void
+NuGet.Configuration.IPackageSourceProvider.SaveAuditSources(System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>! sources) -> void
 NuGet.Configuration.IPackageSourceProvider.SavePackageSources(System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>! sources) -> void
 NuGet.Configuration.IPackageSourceProvider.UpdatePackageSource(NuGet.Configuration.PackageSource! source, bool updateCredentials, bool updateEnabled) -> void
 NuGet.Configuration.IProxyCache
@@ -197,13 +198,11 @@ NuGet.Configuration.PackageSourceProvider
 NuGet.Configuration.PackageSourceProvider.ActivePackageSourceName.get -> string?
 NuGet.Configuration.PackageSourceProvider.AddPackageSource(NuGet.Configuration.PackageSource! source) -> void
 NuGet.Configuration.PackageSourceProvider.DefaultPushSource.get -> string?
-NuGet.Configuration.PackageSourceProvider.DisablePackageSource(NuGet.Configuration.PackageSource! source) -> void
 NuGet.Configuration.PackageSourceProvider.DisablePackageSource(string! name) -> void
 NuGet.Configuration.PackageSourceProvider.EnablePackageSource(string! name) -> void
 NuGet.Configuration.PackageSourceProvider.GetPackageSourceByName(string! name) -> NuGet.Configuration.PackageSource?
 NuGet.Configuration.PackageSourceProvider.GetPackageSourceBySource(string! source) -> NuGet.Configuration.PackageSource?
 NuGet.Configuration.PackageSourceProvider.GetPackageSourceNamesMatchingNamePrefix(string! namePrefix) -> System.Collections.Generic.HashSet<string!>!
-NuGet.Configuration.PackageSourceProvider.IsPackageSourceEnabled(NuGet.Configuration.PackageSource! source) -> bool
 NuGet.Configuration.PackageSourceProvider.IsPackageSourceEnabled(string! name) -> bool
 NuGet.Configuration.PackageSourceProvider.LoadAuditSources() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.PackageSource!>!
 NuGet.Configuration.PackageSourceProvider.LoadPackageSources() -> System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>!
@@ -216,17 +215,15 @@ NuGet.Configuration.PackageSourceProvider.PackageSourceProvider(NuGet.Configurat
 NuGet.Configuration.PackageSourceProvider.PackageSourcesChanged -> System.EventHandler?
 NuGet.Configuration.PackageSourceProvider.RemovePackageSource(string! name) -> void
 NuGet.Configuration.PackageSourceProvider.SaveActivePackageSource(NuGet.Configuration.PackageSource! source) -> void
+NuGet.Configuration.PackageSourceProvider.SaveAuditSources(System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>! sources) -> void
 NuGet.Configuration.PackageSourceProvider.SavePackageSources(System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>! sources) -> void
 NuGet.Configuration.PackageSourceProvider.Settings.get -> NuGet.Configuration.ISettings!
 NuGet.Configuration.PackageSourceProvider.UpdatePackageSource(NuGet.Configuration.PackageSource! source, bool updateCredentials, bool updateEnabled) -> void
 NuGet.Configuration.ProxyCache
-NuGet.Configuration.ProxyCache.Add(System.Net.IWebProxy? proxy) -> void
 NuGet.Configuration.ProxyCache.GetCredential(System.Uri! proxyAddress, string! authType) -> System.Net.NetworkCredential?
-NuGet.Configuration.ProxyCache.GetDefaultProxyCredentials() -> System.Net.ICredentials?
 NuGet.Configuration.ProxyCache.GetProxy(System.Uri! sourceUri) -> System.Net.IWebProxy?
 NuGet.Configuration.ProxyCache.GetUserConfiguredProxy() -> NuGet.Configuration.WebProxy?
 NuGet.Configuration.ProxyCache.ProxyCache(NuGet.Configuration.ISettings! settings, NuGet.Common.IEnvironmentVariableReader! environment) -> void
-NuGet.Configuration.ProxyCache.SetOverrideProxySettings(System.Net.IWebProxy? proxy, System.Net.ICredentials? defaultProxyCredentials) -> void
 NuGet.Configuration.ProxyCache.UpdateCredential(System.Uri! proxyAddress, System.Net.NetworkCredential! credentials) -> void
 NuGet.Configuration.ProxyCache.Version.get -> System.Guid
 NuGet.Configuration.RepositoryItem

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -120,5 +120,33 @@ namespace NuGet.Configuration.Test
             source.IsLocal.Should().BeTrue();
             source.GetHashCode().Should().NotBe(hashCodeBefore);
         }
+
+        [Fact]
+        public void Equals_WithDifferentCredentials_AreNotEqual()
+        {
+            var a = CreateSourceForPasswordEquality("Foo");
+            var b = CreateSourceForPasswordEquality("Bar");
+
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void Equals_WithSameCredentials_AreEqual()
+        {
+            var a = CreateSourceForPasswordEquality("Foo");
+            var b = CreateSourceForPasswordEquality("Foo");
+
+            Assert.Equal(a, b);
+        }
+        private static PackageSource CreateSourceForPasswordEquality(string password)
+        {
+            var credentials = new PackageSourceCredential("SourceName", "username", password, isPasswordClearText: false, null);
+            var source = new PackageSource("Source", "SourceName", isEnabled: false)
+            {
+                Credentials = credentials,
+                ProtocolVersion = 43
+            };
+            return source;
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
@@ -62,5 +62,50 @@ namespace NuGet.Protocol.Tests
             Assert.NotNull(httpSourceResource);
             Assert.Equal(maxHttpRequestsPerSource, sourceRepository.PackageSource.MaxHttpRequestsPerSource);
         }
+
+        [Fact]
+        public async Task WhenSourceRepositoryHasDifferentCredentialsPassword_ReturnsDifferentHttpSourceResources()
+        {
+            // Arrange
+            var sourceRepositoryA = CreateSourceRepositoryForPasswordEquality("Foo");
+            var sourceRepositoryB = CreateSourceRepositoryForPasswordEquality("Bar");
+
+            // Act
+            var provider = new HttpSourceResourceProvider();
+            var a = await provider.TryCreate(sourceRepositoryA, CancellationToken.None);
+            var b = await provider.TryCreate(sourceRepositoryB, CancellationToken.None);
+
+            // Assert
+            Assert.NotSame(a.Item2, b.Item2);
+        }
+
+        [Fact]
+        public async Task WhenSourceRepositoryHasTheSameCredentialsPassword_ReturnsTheSameHttpSourceResource()
+        {
+            // Arrange
+            var sourceRepositoryA = CreateSourceRepositoryForPasswordEquality("Foo");
+            var sourceRepositoryB = CreateSourceRepositoryForPasswordEquality("Foo");
+
+            // Act
+            var provider = new HttpSourceResourceProvider();
+            var a = await provider.TryCreate(sourceRepositoryA, CancellationToken.None);
+            var b = await provider.TryCreate(sourceRepositoryB, CancellationToken.None);
+
+            // Assert
+            Assert.Same(a.Item2, b.Item2);
+        }
+
+        private SourceRepository CreateSourceRepositoryForPasswordEquality(string password)
+        {
+            return new SourceRepository(
+                new PackageSource(_testPackageSourceURL)
+                {
+                    Credentials = new PackageSourceCredential(_testPackageSourceURL, "user", password, true, null)
+                },
+                [
+                    new HttpSourceResourceProvider()
+                ]
+            );
+        }
     }
 }


### PR DESCRIPTION
# Background

We want to keep in lock-step with official Nuget.Client rebase [our changes](https://docs.octopushq.com/docs/features-and-subsystems/NugetFork#octopus-deploys-custom-changes) that we made to Nuget.Client v6 onto the new v7.

This will also resolve the issue we have with V6 not building.

# Results

- Cherry picked feature commits
- Squashed all (ci/cd) fixes into the following commit: [Implemented Octopus Specific CI/CD](https://github.com/OctopusDeploy/NuGet.Client/pull/22/commits/588c9db26dee5645ca11ace54aedef1b481a0f08)
- This should make things easier to rebase in the future

# Quality
I manually confirmed that every file in this PR matches every file in the ([Nuget.Client/release-6.14.x <- OctopusDeploy:NugetClient/release-6.14.x](https://github.com/NuGet/NuGet.Client/compare/release-6.14.x...OctopusDeploy:NuGet.Client:release/release-6.14.x)) 

6.14.x
<img width="2208" height="754" alt="image" src="https://github.com/user-attachments/assets/5a7813c0-ef1a-4552-9cd2-fa3ddce5409d" />

7.3.x
<img width="1659" height="184" alt="image" src="https://github.com/user-attachments/assets/45242a37-3737-4f20-a8e0-3a6bea011cb9" />





# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
