### PR TITLE
Avoid NullReferenceException when requested package version is not on the source

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -473,6 +473,15 @@ namespace NuGet.Commands
                     logger,
                     cancellationToken);
 
+                if (packageDownloader == null)
+                {
+                    // FindPackageByIdResource returns a null downloader when the requested package version does not
+                    // exist on the source. Propagate that null instead of dereferencing it below
+                    // (SetThrottle/SetExceptionHandler), which otherwise throws a bare NullReferenceException for a
+                    // version that isn't on the feed.
+                    return null;
+                }
+
                 packageDownloader.SetThrottle(_throttle);
                 packageDownloader.SetExceptionHandler(async exception =>
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- No upstream NuGet/Home issue exists for this; it surfaced downstream in Octopus. -->
Fixes: n/a — surfaced in OctopusDeploy/Calamari (FD-440). The defect is upstream NuGet code, unchanged since 2017 and still present on upstream's default branch; no open NuGet/Home issue.

## Description

`SourceRepositoryDependencyProvider.GetPackageDownloaderAsync` gets a downloader from the inner `FindPackageByIdResource` and then unconditionally calls `SetThrottle`/`SetExceptionHandler` on it:

```csharp
var packageDownloader = await _findPackagesByIdResource.GetPackageDownloaderAsync(...);
packageDownloader.SetThrottle(_throttle);            // NRE when packageDownloader is null
packageDownloader.SetExceptionHandler(...);
```

The inner method is declared `Task<IPackageDownloader?>` and **returns `null` by contract when the requested version doesn't exist on the source** (e.g. `HttpFileSystemBasedFindPackageByIdResource` returns `null` when the version isn't in the flat-container list). So requesting a downloader for a missing version throws a bare `NullReferenceException` instead of surfacing "not found".

**Why it's gone unnoticed:** restore never reaches this with a missing version, because dependency resolution (`FindLibraryAsync`) validates the version *before* the download step. Callers that request a downloader for a specific version directly — e.g. Octopus Calamari's V3 package download — hit the unprotected path.

**Fix:** null-check the downloader and propagate the `null`, honouring the nullable contract of the resource rather than dereferencing it. No behaviour change for the resolve-then-download path; the previously-NRE case now returns `null` for the caller to handle.

**Targeting / CI:** targets `release/7.4.x`. That branch's GitHub Actions build is currently broken (missing the SDK-resolution fix that only landed on 7.3.x), so #26 ports that fix to 7.4.x and should merge first for this PR to get a green run.

No test added — this is a one-line defensive guard on a code path upstream exercises only indirectly; behavioural coverage lives downstream in Calamari (`GivesActionableErrorWhenV3FeedIsMissingTheRequestedVersion`).

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
